### PR TITLE
Fix SyntaxError in Flask routes main entrypoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -45,5 +45,5 @@ def logout():
     logout_user()
     return redirect(url_for('login'))
 
-if __name__ == \"__main__\":
-    app.run(host=\"0.0.0.0\", port=5000)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- remove stray escape characters around `__main__` check

## Testing
- `python -m py_compile app/routes.py`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a0917810832bb34944ac0823753c