### PR TITLE
Add basic login and home page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+jinja2
+python-multipart

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home</title>
+</head>
+<body>
+    <h1>Welcome {{ user }}</h1>
+    <h2>Hardware Inventory</h2>
+    <table border="1">
+        <tr>
+            <th>ID</th>
+            <th>Demirbaş Adı</th>
+            <th>Marka</th>
+            <th>Model</th>
+            <th>Seri No</th>
+        </tr>
+        {% for item in hardware %}
+        <tr>
+            <td>{{ item.id }}</td>
+            <td>{{ item.demirbas_adi }}</td>
+            <td>{{ item.marka }}</td>
+            <td>{{ item.model }}</td>
+            <td>{{ item.seri_no }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <p><a href="/logout">Logout</a></p>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label for="username">Username:</label>
+        <input type="text" id="username" name="username" required>
+        <br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password" required>
+        <br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add session-based login and logout routes
- show hardware inventory on a simple home page
- include Jinja2 templates and dependencies

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6894baeddd2c832baf6f1b2094934606