### PR TITLE
Add login screen with admin user

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 sqlalchemy
 pydantic
 itsdangerous
+jinja2
+python-multipart

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Giriş</title>
+</head>
+<body>
+    <h2>Hoş geldiniz</h2>
+    {% if error %}
+    <p style="color:red;">{{ error }}</p>
+    {% endif %}
+    <form action="/login" method="post">
+        <label>Kullanıcı Adı: <input type="text" name="username"></label><br>
+        <label>Şifre: <input type="password" name="password"></label><br>
+        <button type="submit">Giriş Yap</button>
+    </form>
+</body>
+</html>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ana Ekran</title>
+</head>
+<body>
+    <h2>Ana Ekran</h2>
+    <p>Merhaba {{ username }}</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce user model and default admin creation
- add basic login flow with welcome message and main screen
- include dependencies for templates and form parsing

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689599e70014832b983f83fad24e5a9b