### PR TITLE
Add login redirect and sidebar pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,8 +172,8 @@ def require_login(
 # --- Ana Sayfa ---
 @app.get("/", response_class=HTMLResponse)
 def root():
-    """Basit bir hoş geldin mesajı döner."""
-    return "<h1>Envanter Sistemine Hoşgeldiniz</h1><p>API kullanımı için /docs adresine gidin.</p>"
+    """Kullanıcıyı giriş sayfasına yönlendir."""
+    return RedirectResponse(url="/login")
 
 
 @app.get("/login", response_class=HTMLResponse)
@@ -193,6 +193,27 @@ def login(request: Request, username: str = Form(...), password: str = Form(...)
 @app.get("/home", response_class=HTMLResponse)
 def home_page(request: Request, username: str):
     return templates.TemplateResponse("main.html", {"request": request, "username": username})
+
+
+# --- Takip Sayfaları (HTML) ---
+@app.get("/envanter", response_class=HTMLResponse)
+def envanter_page(request: Request):
+    return templates.TemplateResponse("envanter.html", {"request": request})
+
+
+@app.get("/lisans", response_class=HTMLResponse)
+def lisans_page(request: Request):
+    return templates.TemplateResponse("lisans.html", {"request": request})
+
+
+@app.get("/yazici", response_class=HTMLResponse)
+def yazici_page(request: Request):
+    return templates.TemplateResponse("yazici.html", {"request": request})
+
+
+@app.get("/stok", response_class=HTMLResponse)
+def stok_page(request: Request):
+    return templates.TemplateResponse("stok.html", {"request": request})
 
 # --- Donanım ---
 @app.get("/hardware", response_model=List[HardwareItem])

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}{% endblock %}</title>
+    <style>
+        body { margin: 0; font-family: Arial, sans-serif; }
+        .sidebar {
+            width: 200px;
+            background: #333;
+            color: #fff;
+            height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            padding-top: 20px;
+        }
+        .sidebar ul { list-style: none; padding: 0; margin: 0; }
+        .sidebar li { padding: 10px; }
+        .sidebar li a { color: #fff; text-decoration: none; display: block; }
+        .sidebar li a:hover { background: #444; }
+        .content { margin-left: 200px; padding: 20px; }
+    </style>
+</head>
+<body>
+    <div class="sidebar">
+        <ul>
+            <li><a href="/envanter">Envanter Takip</a></li>
+            <li><a href="/lisans">Lisans Takip</a></li>
+            <li><a href="/yazici">Yazıcı Takip</a></li>
+            <li><a href="/stok">Stok Takip</a></li>
+        </ul>
+    </div>
+    <div class="content">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Envanter Takip{% endblock %}
+{% block content %}
+<h2>Envanter Takip</h2>
+<p>Envanter kayıtlarını buradan yönetebilirsiniz.</p>
+{% endblock %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Lisans Takip{% endblock %}
+{% block content %}
+<h2>Lisans Takip</h2>
+<p>Lisans bilgilerini buradan takip edebilirsiniz.</p>
+{% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,54 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Ana Ekran</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f4f4f9;
-            margin: 0;
-            padding: 2rem;
-        }
-        .container {
-            max-width: 900px;
-            margin: 0 auto;
-            text-align: center;
-        }
-        h2 {
-            margin-top: 0;
-        }
-        .link-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1rem;
-            margin-top: 2rem;
-        }
-        .card {
-            background: #fff;
-            padding: 1.5rem;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        .card a {
-            text-decoration: none;
-            color: #007bff;
-            font-weight: bold;
-        }
-        .card a:hover {
-            text-decoration: underline;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h2>Merhaba {{ username }}</h2>
-        <div class="link-grid">
-            <div class="card"><a href="/hardware">Donanım Envanteri</a></div>
-            <div class="card"><a href="/printers">Yazıcı Envanteri</a></div>
-            <div class="card"><a href="/licenses">Lisans Envanteri</a></div>
-            <div class="card"><a href="/stock">Stok Takibi</a></div>
-        </div>
-    </div>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Ana Sayfa{% endblock %}
+{% block content %}
+<h2>Hoşgeldiniz {{ username }}</h2>
+<p>Menüden bir seçenek seçiniz.</p>
+{% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Stok Takip{% endblock %}
+{% block content %}
+<h2>Stok Takip</h2>
+<p>Stok hareketlerini buradan izleyebilirsiniz.</p>
+{% endblock %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Yazıcı Takip{% endblock %}
+{% block content %}
+<h2>Yazıcı Takip</h2>
+<p>Yazıcı envanterini buradan görüntüleyebilirsiniz.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Redirect root path to login and add page routes for Envanter, Lisans, Yazıcı and Stok tracking
- Introduce base template with sidebar navigation and welcome message on home page
- Provide individual HTML templates for each tracking section

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895b27c6940832b9222233916f0e920