### PR TITLE
Add sidebar routes with placeholder tracking pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,23 +195,23 @@ def home_page(request: Request, username: Optional[str] = None):
 
 
 # --- Takip Sayfaları (HTML) ---
-@app.get("/envanter", response_class=HTMLResponse)
-def envanter_page(request: Request):
+@app.get("/inventory", response_class=HTMLResponse)
+def inventory_page(request: Request):
     return templates.TemplateResponse("envanter.html", {"request": request})
 
 
-@app.get("/lisans", response_class=HTMLResponse)
-def lisans_page(request: Request):
+@app.get("/license", response_class=HTMLResponse)
+def license_page(request: Request):
     return templates.TemplateResponse("lisans.html", {"request": request})
 
 
-@app.get("/yazici", response_class=HTMLResponse)
-def yazici_page(request: Request):
+@app.get("/printer", response_class=HTMLResponse)
+def printer_page(request: Request):
     return templates.TemplateResponse("yazici.html", {"request": request})
 
 
-@app.get("/stok", response_class=HTMLResponse)
-def stok_page(request: Request):
+@app.get("/stock", response_class=HTMLResponse)
+def stock_page(request: Request):
     return templates.TemplateResponse("stok.html", {"request": request})
 
 # --- Donanım ---
@@ -272,13 +272,13 @@ def add_license(
     return db_item
 
 # --- Stok ---
-@app.get("/stock", response_model=List[StockItemSchema])
+@app.get("/stock_items", response_model=List[StockItemSchema])
 def get_stock(
     user: User = Depends(require_login), db: Session = Depends(get_db)
 ):
     return db.query(StockItem).all()
 
-@app.post("/stock", response_model=StockItemSchema)
+@app.post("/stock_items", response_model=StockItemSchema)
 def add_stock(
     item: StockItemSchema,
     user: User = Depends(require_login),

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,10 +25,10 @@
 <body>
     <div class="sidebar">
         <ul>
-            <li><a href="/envanter">Envanter Takip</a></li>
-            <li><a href="/lisans">Lisans Takip</a></li>
-            <li><a href="/yazici">Yazıcı Takip</a></li>
-            <li><a href="/stok">Stok Takip</a></li>
+            <li><a href="/inventory">Envanter Takip</a></li>
+            <li><a href="/license">Lisans Takip</a></li>
+            <li><a href="/printer">Yazıcı Takip</a></li>
+            <li><a href="/stock">Stok Takip</a></li>
         </ul>
     </div>
     <div class="content">

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Envanter Takip{% endblock %}
 {% block content %}
-<h2>Envanter Takip</h2>
+<h2>Burası Envanter Takip Sayfası</h2>
 <p>Envanter kayıtlarını buradan yönetebilirsiniz.</p>
+<table border="1">
+    <tr><th>ID</th><th>Örnek Başlık</th></tr>
+    <tr><td>1</td><td>Örnek Veri</td></tr>
+</table>
 {% endblock %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Lisans Takip{% endblock %}
 {% block content %}
-<h2>Lisans Takip</h2>
+<h2>Burası Lisans Takip Sayfası</h2>
 <p>Lisans bilgilerini buradan takip edebilirsiniz.</p>
+<table border="1">
+    <tr><th>ID</th><th>Örnek Lisans</th></tr>
+    <tr><td>1</td><td>Örnek Veri</td></tr>
+</table>
 {% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Stok Takip{% endblock %}
 {% block content %}
-<h2>Stok Takip</h2>
+<h2>Burası Stok Takip Sayfası</h2>
 <p>Stok hareketlerini buradan izleyebilirsiniz.</p>
+<table border="1">
+    <tr><th>ID</th><th>Örnek Stok</th></tr>
+    <tr><td>1</td><td>Örnek Veri</td></tr>
+</table>
 {% endblock %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Yazıcı Takip{% endblock %}
 {% block content %}
-<h2>Yazıcı Takip</h2>
+<h2>Burası Yazıcı Takip Sayfası</h2>
 <p>Yazıcı envanterini buradan görüntüleyebilirsiniz.</p>
+<table border="1">
+    <tr><th>ID</th><th>Örnek Yazıcı</th></tr>
+    <tr><td>1</td><td>Örnek Veri</td></tr>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Implement `/inventory`, `/license`, `/printer`, `/stock` routes and update sidebar links
- Provide placeholder tracking pages with introductory headings and sample tables
- Rename stock API endpoints to `/stock_items` to avoid conflict with new page routes

## Testing
- `python -m py_compile main.py`
- `uvicorn main:app --host 127.0.0.1 --port 5000 --log-level warning`


------
https://chatgpt.com/codex/tasks/task_e_6895b7aac46c832ba82541d90b42bb6e