### PR TITLE
Allow configurable port for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ COPY . .
 COPY data/envanter.db ./data/envanter.db
 
 # Uvicorn ile FastAPI uygulamasini baslat
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]
+# Allow the port to be overridden at runtime via the PORT environment variable.
+# Defaults to 5000 if PORT is not set.
+CMD ["bash", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-5000}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   envanter:
     build: .
     ports:
-      - "5000:5000"
+      - "${HOST_PORT:-5000}:5000"
     environment:
       - DB_FILE=./data/envanter.db


### PR DESCRIPTION
## Summary
- allow overriding internal port in Dockerfile via PORT env
- expose host port in docker-compose via HOST_PORT variable to avoid conflicts

## Testing
- `python -m py_compile main.py && echo py_compile_success`
- `docker compose config >/tmp/docker-config.txt && cat /tmp/docker-config.txt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd166748832b9451cf047e0e1c24