### PR TITLE
Handle uppercase Excel extensions in printer upload

### DIFF
--- a/main.py
+++ b/main.py
@@ -273,7 +273,9 @@ async def upload_printer_excel(
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
-    if not excel_file.filename.endswith((".xls", ".xlsx")):
+    # Dosya uzantısını küçük harfe çevirerek Excel dosyası kontrolünü
+    # büyük/küçük harf duyarlılığından bağımsız hale getir
+    if not excel_file.filename.lower().endswith((".xls", ".xlsx")):
         raise HTTPException(status_code=400, detail="Sadece Excel dosyaları yüklenebilir.")
     contents = await excel_file.read()
     try:


### PR DESCRIPTION
## Summary
- Allow printer inventory Excel uploads with uppercase file extensions by normalizing filenames to lowercase before validation.

## Testing
- `python - <<'PY'
from fastapi.testclient import TestClient
import main
client=TestClient(main.app)
import pandas as pd
from io import BytesIO
cols=['Yazıcı Adı','Marka','Model','IP Adresi','Seri No','Lokasyon','Zimmetli Kişi','Notlar']
df=pd.DataFrame({c:[c] for c in cols})
buf=BytesIO()
with pd.ExcelWriter(buf, engine='openpyxl') as writer:
    df.to_excel(writer, index=False)
buf.seek(0)
files={'excel_file':('FILE.XLSX', buf, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')}
resp=client.post('/printer/upload', files=files, auth=('admin','admin'))
print('status code', resp.status_code)
print('response length', len(resp.text))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689601521f54832b8699e030bb0e6e1c