### PR TITLE
Revise printer inventory schema

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,13 +37,12 @@ class HardwareInventory(Base):
 class PrinterInventory(Base):
     __tablename__ = "printer_inventory"
     id = Column(Integer, primary_key=True, index=True)
-    yazici_adi = Column(String)
-    marka = Column(String)
-    model = Column(String)
+    yazici_markasi = Column(String)
+    yazici_modeli = Column(String)
+    kullanim_alani = Column(String)
     ip_adresi = Column(String)
-    seri_no = Column(String)
-    lokasyon = Column(String)
-    zimmetli_kisi = Column(String)
+    mac = Column(String)
+    hostname = Column(String)
     notlar = Column(Text)
 
 class LicenseInventory(Base):
@@ -106,13 +105,12 @@ class HardwareItem(BaseModel):
 
 class PrinterItem(BaseModel):
     id: Optional[int]
-    yazici_adi: str
-    marka: str
-    model: str
+    yazici_markasi: str
+    yazici_modeli: str
+    kullanim_alani: str
     ip_adresi: str
-    seri_no: str
-    lokasyon: str
-    zimmetli_kisi: str
+    mac: str
+    hostname: str
     notlar: Optional[str]
     class Config:
         orm_mode = True
@@ -222,26 +220,24 @@ def printer_page(
 
 @app.post("/printer/add")
 def add_printer_form(
-    yazici_adi: str = Form(...),
-    marka: str = Form(...),
-    model: str = Form(...),
+    yazici_markasi: str = Form(...),
+    yazici_modeli: str = Form(...),
+    kullanim_alani: str = Form(...),
     ip_adresi: str = Form(...),
-    seri_no: str = Form(...),
-    lokasyon: str = Form(...),
-    zimmetli_kisi: str = Form(...),
+    mac: str = Form(...),
+    hostname: str = Form(...),
     notlar: str = Form(""),
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
     """Formdan gelen verilerle yeni yazıcı kaydı oluşturur."""
     db_item = PrinterInventory(
-        yazici_adi=yazici_adi,
-        marka=marka,
-        model=model,
+        yazici_markasi=yazici_markasi,
+        yazici_modeli=yazici_modeli,
+        kullanim_alani=kullanim_alani,
         ip_adresi=ip_adresi,
-        seri_no=seri_no,
-        lokasyon=lokasyon,
-        zimmetli_kisi=zimmetli_kisi,
+        mac=mac,
+        hostname=hostname,
         notlar=notlar,
     )
     db.add(db_item)

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -4,13 +4,12 @@
 <h2>Yazıcı Envanteri</h2>
 
 <form action="/printer/add" method="post">
-    <input type="text" name="yazici_adi" placeholder="Yazıcı Adı" required>
-    <input type="text" name="marka" placeholder="Marka" required>
-    <input type="text" name="model" placeholder="Model" required>
+    <input type="text" name="yazici_markasi" placeholder="Yazıcı Markası" required>
+    <input type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
+    <input type="text" name="kullanim_alani" placeholder="Kullanım Alanı" required>
     <input type="text" name="ip_adresi" placeholder="IP Adresi" required>
-    <input type="text" name="seri_no" placeholder="Seri No" required>
-    <input type="text" name="lokasyon" placeholder="Lokasyon" required>
-    <input type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
+    <input type="text" name="mac" placeholder="MAC" required>
+    <input type="text" name="hostname" placeholder="Hostname" required>
     <input type="text" name="notlar" placeholder="Notlar">
     <button type="submit">Ekle</button>
     <br><br>
@@ -25,26 +24,24 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>Yazıcı Adı</th>
-        <th>Marka</th>
-        <th>Model</th>
+        <th>Yazıcı Markası</th>
+        <th>Yazıcı Modeli</th>
+        <th>Kullanım Alanı</th>
         <th>IP</th>
-        <th>Seri No</th>
-        <th>Lokasyon</th>
-        <th>Zimmetli Kişi</th>
+        <th>MAC</th>
+        <th>Hostname</th>
         <th>Notlar</th>
         <th>Sil</th>
     </tr>
     {% for p in printers %}
     <tr>
         <td>{{ p.id }}</td>
-        <td>{{ p.yazici_adi }}</td>
-        <td>{{ p.marka }}</td>
-        <td>{{ p.model }}</td>
+        <td>{{ p.yazici_markasi }}</td>
+        <td>{{ p.yazici_modeli }}</td>
+        <td>{{ p.kullanim_alani }}</td>
         <td>{{ p.ip_adresi }}</td>
-        <td>{{ p.seri_no }}</td>
-        <td>{{ p.lokasyon }}</td>
-        <td>{{ p.zimmetli_kisi }}</td>
+        <td>{{ p.mac }}</td>
+        <td>{{ p.hostname }}</td>
         <td>{{ p.notlar }}</td>
         <td>
             <form action="/printer/delete/{{ p.id }}" method="post" style="display:inline;">


### PR DESCRIPTION
## Summary
- refactor PrinterInventory and PrinterItem to use fields for brand, model, usage area, IP, MAC, hostname, and notes
- align printer add form and listing template with the new schema

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68960d9870e4832b8a4ff8cf500f8fae