### PR TITLE
Persist database across docker-compose down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       - "${HOST_PORT:-5000}:5000"
     environment:
       - DB_FILE=./data/envanter.db
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
## Summary
- Mount `data` directory as a volume in docker-compose to keep SQLite database

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6896493baba0832bb2086277d5b9cc54