### PR TITLE
Add Onurum logo to login and home pages

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -50,6 +50,7 @@
 </head>
 <body>
     <div class="login-container">
+        <img src="/image/onurum.png" alt="Onurum" style="width: 100px; margin-bottom: 1rem;">
         <h2>Hoş geldiniz</h2>
         {% if error %}
         <p class="error">{{ error }}</p>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Ana Sayfa{% endblock %}
 {% block content %}
+<img src="/image/onurum.png" alt="Onurum" style="width: 100px; display: block; margin-bottom: 1rem;">
 <h2>Hoşgeldiniz {{ username }}</h2>
 <p>Menüden bir seçenek seçiniz.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display Onurum logo above welcome text on login screen
- show Onurum logo at top of home page

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68964af13f30832ba750a0a7c56a8a99