### PR TITLE
Expose image directory as static files

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 
 from fastapi import FastAPI, Depends, Request, Form, HTTPException, status, UploadFile, File
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from io import BytesIO
 import pandas as pd
 from fastapi.templating import Jinja2Templates
@@ -140,6 +141,7 @@ class StockItemSchema(BaseModel):
 
 # --- FastAPI Uygulaması ---
 app = FastAPI()
+app.mount("/image", StaticFiles(directory="image"), name="image")
 templates = Jinja2Templates(directory="templates")
 
 # --- Dependency ---


### PR DESCRIPTION
## Summary
- Serve `/image` from the container's `image` folder using FastAPI `StaticFiles`

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
from fastapi.testclient import TestClient
import main
client = TestClient(main.app)
resp = client.get('/image/onurum.png')
print('status', resp.status_code)
print('content-type', resp.headers.get('content-type'))
print('length', len(resp.content))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68964e574d4c832ba8aeb96744887d7e