### PR TITLE
Add sidebar logo above inventory link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
 </head>
 <body>
     <div class="sidebar">
+        <img src="/image/onurum.png" alt="Onurum" style="width: 100px; display: block; margin: 0 auto 1rem;">
         <ul>
             <li><a href="/inventory">Envanter Takip</a></li>
             <li><a href="/license">Lisans Takip</a></li>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Ana Sayfa{% endblock %}
 {% block content %}
-<img src="/image/onurum.png" alt="Onurum" style="width: 100px; display: block; margin-bottom: 1rem;">
 <h2>Hoşgeldiniz {{ username }}</h2>
 <p>Menüden bir seçenek seçiniz.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show logo above the Envanter Takip link in the sidebar for all authenticated pages
- Remove duplicate logo from the home page content

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68965442614c832bbbedc8dd101a4e58