### PR TITLE
Place logo at top of sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,11 @@
             position: fixed;
             top: 0;
             left: 0;
-            padding-top: 20px;
+        }
+        .sidebar-logo {
+            width: 100px;
+            display: block;
+            margin: 0 auto 1rem;
         }
         .sidebar ul { list-style: none; padding: 0; margin: 0; }
         .sidebar li { padding: 10px; }
@@ -24,7 +28,7 @@
 </head>
 <body>
     <div class="sidebar">
-        <img src="/image/onurum.png" alt="Onurum" style="width: 100px; display: block; margin: 0 auto 1rem;">
+        <img src="/image/onurum.png" alt="Onurum" class="sidebar-logo">
         <ul>
             <li><a href="/inventory">Envanter Takip</a></li>
             <li><a href="/license">Lisans Takip</a></li>


### PR DESCRIPTION
## Summary
- Style the Onurum logo via a dedicated CSS class and remove extra padding so the logo sits at the sidebar's top.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689656cf6050832b9725915a161aae8c