### PR TITLE
Fix printer upload column name mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -673,7 +673,7 @@ async def upload_printer_excel(
 
         for _, row in df.iterrows():
             printer = PrinterInventory(
-                marka=str(row["yazici_markasi"]),
+                yazici_markasi=str(row["yazici_markasi"]),
                 yazici_modeli=str(row["yazici_modeli"]),
                 kullanim_alani=str(row["kullanim_alani"]),
                 ip_adresi=str(row["ip_adresi"]),


### PR DESCRIPTION
## Summary
- fix printer upload by mapping `yazici_markasi` correctly

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899cf99f3f4832b8747e80fc9aa7144