### PR TITLE
Add configurable column settings per user

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -3,6 +3,14 @@
 {% block content %}
 <h2>Donanım Envanteri</h2>
 
+<button id="settings-btn">Ayarlar</button>
+<div id="settings-modal" style="display:none; position:fixed; top:20%; left:30%; background:#fff; border:1px solid #000; padding:10px;">
+    <h3>Kolon Ayarları</h3>
+    <ul id="columns-list"></ul>
+    <button id="save-settings" type="button">Kaydet</button>
+    <button type="button" onclick="document.getElementById('settings-modal').style.display='none'">Kapat</button>
+</div>
+
 <form action="/inventory/add" method="post">
     <input type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required>
     <input type="text" name="marka" placeholder="Marka" required>
@@ -23,26 +31,16 @@
 
 <table border="1">
     <tr>
-        <th>ID</th>
-        <th>Demirbaş Adı</th>
-        <th>Marka</th>
-        <th>Model</th>
-        <th>Seri No</th>
-        <th>Lokasyon</th>
-        <th>Zimmetli Kişi</th>
-        <th>Notlar</th>
+        {% for col in columns %}
+        <th>{{ col.replace('_', ' ').title() }}</th>
+        {% endfor %}
         <th>Sil</th>
     </tr>
     {% for i in items %}
     <tr>
-        <td>{{ i.id }}</td>
-        <td>{{ i.demirbas_adi }}</td>
-        <td>{{ i.marka }}</td>
-        <td>{{ i.model }}</td>
-        <td>{{ i.seri_no }}</td>
-        <td>{{ i.lokasyon }}</td>
-        <td>{{ i.zimmetli_kisi }}</td>
-        <td>{{ i.notlar }}</td>
+        {% for col in columns %}
+        <td>{{ i|attr(col) }}</td>
+        {% endfor %}
         <td>
             <form action="/inventory/delete/{{ i.id }}" method="post" style="display:inline;">
                 <button type="submit">Sil</button>
@@ -51,4 +49,50 @@
     </tr>
     {% endfor %}
 </table>
+
+<script>
+const tableName = "{{ table_name }}";
+document.getElementById('settings-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('settings-modal');
+    modal.style.display = 'block';
+    const res = await fetch(`/table-columns?table_name=${tableName}`);
+    const allCols = (await res.json()).columns;
+    const settingsRes = await fetch(`/column-settings?table_name=${tableName}`);
+    const settings = await settingsRes.json();
+    const order = settings.order || allCols;
+    const visible = new Set(settings.visible || allCols);
+    const list = document.getElementById('columns-list');
+    list.innerHTML = '';
+    order.forEach(col => {
+        const li = document.createElement('li');
+        li.draggable = true;
+        li.dataset.col = col;
+        li.innerHTML = `<label><input type="checkbox" ${visible.has(col) ? 'checked' : ''}> ${col}</label>`;
+        list.appendChild(li);
+    });
+    let drag;
+    list.addEventListener('dragstart', e => { drag = e.target; });
+    list.addEventListener('dragover', e => e.preventDefault());
+    list.addEventListener('drop', e => {
+        e.preventDefault();
+        if (e.target.tagName === 'LI' && drag !== e.target) {
+            list.insertBefore(drag, e.target.nextSibling);
+        }
+    });
+});
+
+document.getElementById('save-settings').addEventListener('click', async () => {
+    const items = document.querySelectorAll('#columns-list li');
+    const order = Array.from(items).map(li => li.dataset.col);
+    const visible = Array.from(items)
+        .filter(li => li.querySelector('input').checked)
+        .map(li => li.dataset.col);
+    await fetch(`/column-settings?table_name=${tableName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order, visible })
+    });
+    location.reload();
+});
+</script>
 {% endblock %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -3,6 +3,14 @@
 {% block content %}
 <h2>Lisans Envanteri</h2>
 
+<button id="settings-btn">Ayarlar</button>
+<div id="settings-modal" style="display:none; position:fixed; top:20%; left:30%; background:#fff; border:1px solid #000; padding:10px;">
+    <h3>Kolon Ayarları</h3>
+    <ul id="columns-list"></ul>
+    <button id="save-settings" type="button">Kaydet</button>
+    <button type="button" onclick="document.getElementById('settings-modal').style.display='none'">Kapat</button>
+</div>
+
 <form action="/license/add" method="post">
     <input type="text" name="yazilim_adi" placeholder="Yazılım Adı" required>
     <input type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required>
@@ -23,26 +31,16 @@
 
 <table border="1">
     <tr>
-        <th>ID</th>
-        <th>Yazılım Adı</th>
-        <th>Lisans Anahtarı</th>
-        <th>Adet</th>
-        <th>Satın Alma Tarihi</th>
-        <th>Bitiş Tarihi</th>
-        <th>Zimmetli Kişi</th>
-        <th>Notlar</th>
+        {% for col in columns %}
+        <th>{{ col.replace('_', ' ').title() }}</th>
+        {% endfor %}
         <th>Sil</th>
     </tr>
     {% for l in licenses %}
     <tr>
-        <td>{{ l.id }}</td>
-        <td>{{ l.yazilim_adi }}</td>
-        <td>{{ l.lisans_anahtari }}</td>
-        <td>{{ l.adet }}</td>
-        <td>{{ l.satin_alma_tarihi }}</td>
-        <td>{{ l.bitis_tarihi }}</td>
-        <td>{{ l.zimmetli_kisi }}</td>
-        <td>{{ l.notlar }}</td>
+        {% for col in columns %}
+        <td>{{ l|attr(col) }}</td>
+        {% endfor %}
         <td>
             <form action="/license/delete/{{ l.id }}" method="post" style="display:inline;">
                 <button type="submit">Sil</button>
@@ -51,4 +49,50 @@
     </tr>
     {% endfor %}
 </table>
+
+<script>
+const tableName = "{{ table_name }}";
+document.getElementById('settings-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('settings-modal');
+    modal.style.display = 'block';
+    const res = await fetch(`/table-columns?table_name=${tableName}`);
+    const allCols = (await res.json()).columns;
+    const settingsRes = await fetch(`/column-settings?table_name=${tableName}`);
+    const settings = await settingsRes.json();
+    const order = settings.order || allCols;
+    const visible = new Set(settings.visible || allCols);
+    const list = document.getElementById('columns-list');
+    list.innerHTML = '';
+    order.forEach(col => {
+        const li = document.createElement('li');
+        li.draggable = true;
+        li.dataset.col = col;
+        li.innerHTML = `<label><input type="checkbox" ${visible.has(col) ? 'checked' : ''}> ${col}</label>`;
+        list.appendChild(li);
+    });
+    let drag;
+    list.addEventListener('dragstart', e => { drag = e.target; });
+    list.addEventListener('dragover', e => e.preventDefault());
+    list.addEventListener('drop', e => {
+        e.preventDefault();
+        if (e.target.tagName === 'LI' && drag !== e.target) {
+            list.insertBefore(drag, e.target.nextSibling);
+        }
+    });
+});
+
+document.getElementById('save-settings').addEventListener('click', async () => {
+    const items = document.querySelectorAll('#columns-list li');
+    const order = Array.from(items).map(li => li.dataset.col);
+    const visible = Array.from(items)
+        .filter(li => li.querySelector('input').checked)
+        .map(li => li.dataset.col);
+    await fetch(`/column-settings?table_name=${tableName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order, visible })
+    });
+    location.reload();
+});
+</script>
 {% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -3,6 +3,14 @@
 {% block content %}
 <h2>Stok Takibi</h2>
 
+<button id="settings-btn">Ayarlar</button>
+<div id="settings-modal" style="display:none; position:fixed; top:20%; left:30%; background:#fff; border:1px solid #000; padding:10px;">
+    <h3>Kolon Ayarları</h3>
+    <ul id="columns-list"></ul>
+    <button id="save-settings" type="button">Kaydet</button>
+    <button type="button" onclick="document.getElementById('settings-modal').style.display='none'">Kapat</button>
+</div>
+
 <form action="/stock/add" method="post">
     <input type="text" name="urun_adi" placeholder="Ürün Adı" required>
     <input type="text" name="kategori" placeholder="Kategori" required>
@@ -22,24 +30,16 @@
 
 <table border="1">
     <tr>
-        <th>ID</th>
-        <th>Ürün Adı</th>
-        <th>Kategori</th>
-        <th>Marka</th>
-        <th>Adet</th>
-        <th>Lokasyon</th>
-        <th>Güncelleme Tarihi</th>
+        {% for col in columns %}
+        <th>{{ col.replace('_', ' ').title() }}</th>
+        {% endfor %}
         <th>Sil</th>
     </tr>
     {% for s in stocks %}
     <tr>
-        <td>{{ s.id }}</td>
-        <td>{{ s.urun_adi }}</td>
-        <td>{{ s.kategori }}</td>
-        <td>{{ s.marka }}</td>
-        <td>{{ s.adet }}</td>
-        <td>{{ s.lokasyon }}</td>
-        <td>{{ s.guncelleme_tarihi }}</td>
+        {% for col in columns %}
+        <td>{{ s|attr(col) }}</td>
+        {% endfor %}
         <td>
             <form action="/stock/delete/{{ s.id }}" method="post" style="display:inline;">
                 <button type="submit">Sil</button>
@@ -48,4 +48,50 @@
     </tr>
     {% endfor %}
 </table>
+
+<script>
+const tableName = "{{ table_name }}";
+document.getElementById('settings-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('settings-modal');
+    modal.style.display = 'block';
+    const res = await fetch(`/table-columns?table_name=${tableName}`);
+    const allCols = (await res.json()).columns;
+    const settingsRes = await fetch(`/column-settings?table_name=${tableName}`);
+    const settings = await settingsRes.json();
+    const order = settings.order || allCols;
+    const visible = new Set(settings.visible || allCols);
+    const list = document.getElementById('columns-list');
+    list.innerHTML = '';
+    order.forEach(col => {
+        const li = document.createElement('li');
+        li.draggable = true;
+        li.dataset.col = col;
+        li.innerHTML = `<label><input type="checkbox" ${visible.has(col) ? 'checked' : ''}> ${col}</label>`;
+        list.appendChild(li);
+    });
+    let drag;
+    list.addEventListener('dragstart', e => { drag = e.target; });
+    list.addEventListener('dragover', e => e.preventDefault());
+    list.addEventListener('drop', e => {
+        e.preventDefault();
+        if (e.target.tagName === 'LI' && drag !== e.target) {
+            list.insertBefore(drag, e.target.nextSibling);
+        }
+    });
+});
+
+document.getElementById('save-settings').addEventListener('click', async () => {
+    const items = document.querySelectorAll('#columns-list li');
+    const order = Array.from(items).map(li => li.dataset.col);
+    const visible = Array.from(items)
+        .filter(li => li.querySelector('input').checked)
+        .map(li => li.dataset.col);
+    await fetch(`/column-settings?table_name=${tableName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order, visible })
+    });
+    location.reload();
+});
+</script>
 {% endblock %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -3,6 +3,14 @@
 {% block content %}
 <h2>Yazıcı Envanteri</h2>
 
+<button id="settings-btn">Ayarlar</button>
+<div id="settings-modal" style="display:none; position:fixed; top:20%; left:30%; background:#fff; border:1px solid #000; padding:10px;">
+    <h3>Kolon Ayarları</h3>
+    <ul id="columns-list"></ul>
+    <button id="save-settings" type="button">Kaydet</button>
+    <button type="button" onclick="document.getElementById('settings-modal').style.display='none'">Kapat</button>
+</div>
+
 <form action="/printer/add" method="post">
     <input type="text" name="yazici_markasi" placeholder="Yazıcı Markası" required>
     <input type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
@@ -23,26 +31,16 @@
 
 <table border="1">
     <tr>
-        <th>ID</th>
-        <th>Yazıcı Markası</th>
-        <th>Yazıcı Modeli</th>
-        <th>Kullanım Alanı</th>
-        <th>IP</th>
-        <th>MAC</th>
-        <th>Hostname</th>
-        <th>Notlar</th>
+        {% for col in columns %}
+        <th>{{ col.replace('_', ' ').title() }}</th>
+        {% endfor %}
         <th>Sil</th>
     </tr>
     {% for p in printers %}
     <tr>
-        <td>{{ p.id }}</td>
-        <td>{{ p.yazici_markasi }}</td>
-        <td>{{ p.yazici_modeli }}</td>
-        <td>{{ p.kullanim_alani }}</td>
-        <td>{{ p.ip_adresi }}</td>
-        <td>{{ p.mac }}</td>
-        <td>{{ p.hostname }}</td>
-        <td>{{ p.notlar }}</td>
+        {% for col in columns %}
+        <td>{{ p|attr(col) }}</td>
+        {% endfor %}
         <td>
             <form action="/printer/delete/{{ p.id }}" method="post" style="display:inline;">
                 <button type="submit">Sil</button>
@@ -51,4 +49,50 @@
     </tr>
     {% endfor %}
 </table>
+
+<script>
+const tableName = "{{ table_name }}";
+document.getElementById('settings-btn').addEventListener('click', async () => {
+    const modal = document.getElementById('settings-modal');
+    modal.style.display = 'block';
+    const res = await fetch(`/table-columns?table_name=${tableName}`);
+    const allCols = (await res.json()).columns;
+    const settingsRes = await fetch(`/column-settings?table_name=${tableName}`);
+    const settings = await settingsRes.json();
+    const order = settings.order || allCols;
+    const visible = new Set(settings.visible || allCols);
+    const list = document.getElementById('columns-list');
+    list.innerHTML = '';
+    order.forEach(col => {
+        const li = document.createElement('li');
+        li.draggable = true;
+        li.dataset.col = col;
+        li.innerHTML = `<label><input type="checkbox" ${visible.has(col) ? 'checked' : ''}> ${col}</label>`;
+        list.appendChild(li);
+    });
+    let drag;
+    list.addEventListener('dragstart', e => { drag = e.target; });
+    list.addEventListener('dragover', e => e.preventDefault());
+    list.addEventListener('drop', e => {
+        e.preventDefault();
+        if (e.target.tagName === 'LI' && drag !== e.target) {
+            list.insertBefore(drag, e.target.nextSibling);
+        }
+    });
+});
+
+document.getElementById('save-settings').addEventListener('click', async () => {
+    const items = document.querySelectorAll('#columns-list li');
+    const order = Array.from(items).map(li => li.dataset.col);
+    const visible = Array.from(items)
+        .filter(li => li.querySelector('input').checked)
+        .map(li => li.dataset.col);
+    await fetch(`/column-settings?table_name=${tableName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order, visible })
+    });
+    location.reload();
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow users to customize table columns for inventory, printer, license and stock pages
- persist per-user column visibility and order in a JSON file
- support drag-and-drop column arrangement via new settings modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6899d0145f5c832b9456d6ce51f19c43