### PR TITLE
Add icon-based settings and add modals

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>{% block title %}{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <style>
     :root{ --sidebar: #333; --sidebar-hover:#444; --active:#555; }
     *{ box-sizing: border-box; }

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -3,7 +3,14 @@
 {% block content %}
 <h2>Donanım Envanteri</h2>
 
-<button class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#settingsModal">Ayarlar</button>
+<div class="d-flex gap-2 mb-3">
+  <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#settingsModal">
+    <i class="bi bi-gear"></i>
+  </button>
+  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+    <i class="bi bi-plus"></i>
+  </button>
+</div>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -23,18 +30,30 @@
   </div>
 </div>
 
-<form action="/inventory/add" method="post" class="mb-4">
-    <div class="row g-2">
-        <div class="col"><input class="form-control" type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required></div>
-        <div class="col"><input class="form-control" type="text" name="marka" placeholder="Marka" required></div>
-        <div class="col"><input class="form-control" type="text" name="model" placeholder="Model" required></div>
-        <div class="col"><input class="form-control" type="text" name="seri_no" placeholder="Seri No" required></div>
-        <div class="col"><input class="form-control" type="text" name="lokasyon" placeholder="Lokasyon" required></div>
-        <div class="col"><input class="form-control" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required></div>
-        <div class="col"><input class="form-control" type="text" name="notlar" placeholder="Notlar"></div>
-        <div class="col-12"><button type="submit" class="btn btn-success">Ekle</button></div>
+<div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addModalLabel">Yeni Kayıt</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form id="addForm" action="/inventory/add" method="post">
+        <div class="modal-body">
+          <input class="form-control mb-2" type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required>
+          <input class="form-control mb-2" type="text" name="marka" placeholder="Marka" required>
+          <input class="form-control mb-2" type="text" name="model" placeholder="Model" required>
+          <input class="form-control mb-2" type="text" name="seri_no" placeholder="Seri No" required>
+          <input class="form-control mb-2" type="text" name="lokasyon" placeholder="Lokasyon" required>
+          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
+          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Ekle</button>
+        </div>
+      </form>
     </div>
-</form>
+  </div>
+</div>
 
 <form action="/inventory/upload" method="post" enctype="multipart/form-data" class="mb-4">
     <div class="input-group">

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -3,7 +3,14 @@
 {% block content %}
 <h2>Lisans Envanteri</h2>
 
-<button class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#settingsModal">Ayarlar</button>
+<div class="d-flex gap-2 mb-3">
+  <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#settingsModal">
+    <i class="bi bi-gear"></i>
+  </button>
+  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+    <i class="bi bi-plus"></i>
+  </button>
+</div>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -23,18 +30,30 @@
   </div>
 </div>
 
-<form action="/license/add" method="post" class="mb-4">
-    <div class="row g-2">
-        <div class="col"><input class="form-control" type="text" name="yazilim_adi" placeholder="Yazılım Adı" required></div>
-        <div class="col"><input class="form-control" type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required></div>
-        <div class="col"><input class="form-control" type="number" name="adet" placeholder="Adet" required></div>
-        <div class="col"><input class="form-control" type="date" name="satin_alma_tarihi" placeholder="Satın Alma Tarihi"></div>
-        <div class="col"><input class="form-control" type="date" name="bitis_tarihi" placeholder="Bitiş Tarihi"></div>
-        <div class="col"><input class="form-control" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required></div>
-        <div class="col"><input class="form-control" type="text" name="notlar" placeholder="Notlar"></div>
-        <div class="col-12"><button type="submit" class="btn btn-success">Ekle</button></div>
+<div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addModalLabel">Yeni Kayıt</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form id="addForm" action="/license/add" method="post">
+        <div class="modal-body">
+          <input class="form-control mb-2" type="text" name="yazilim_adi" placeholder="Yazılım Adı" required>
+          <input class="form-control mb-2" type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required>
+          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
+          <input class="form-control mb-2" type="date" name="satin_alma_tarihi" placeholder="Satın Alma Tarihi">
+          <input class="form-control mb-2" type="date" name="bitis_tarihi" placeholder="Bitiş Tarihi">
+          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
+          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Ekle</button>
+        </div>
+      </form>
     </div>
-</form>
+  </div>
+</div>
 
 <form action="/license/upload" method="post" enctype="multipart/form-data" class="mb-4">
     <div class="input-group">

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -3,7 +3,14 @@
 {% block content %}
 <h2>Stok Takibi</h2>
 
-<button class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#settingsModal">Ayarlar</button>
+<div class="d-flex gap-2 mb-3">
+  <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#settingsModal">
+    <i class="bi bi-gear"></i>
+  </button>
+  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+    <i class="bi bi-plus"></i>
+  </button>
+</div>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -23,17 +30,29 @@
   </div>
 </div>
 
-<form action="/stock/add" method="post" class="mb-4">
-    <div class="row g-2">
-        <div class="col"><input class="form-control" type="text" name="urun_adi" placeholder="Ürün Adı" required></div>
-        <div class="col"><input class="form-control" type="text" name="kategori" placeholder="Kategori" required></div>
-        <div class="col"><input class="form-control" type="text" name="marka" placeholder="Marka" required></div>
-        <div class="col"><input class="form-control" type="number" name="adet" placeholder="Adet" required></div>
-        <div class="col"><input class="form-control" type="text" name="lokasyon" placeholder="Lokasyon" required></div>
-        <div class="col"><input class="form-control" type="date" name="guncelleme_tarihi" placeholder="Güncelleme Tarihi"></div>
-        <div class="col-12"><button type="submit" class="btn btn-success">Ekle</button></div>
+<div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addModalLabel">Yeni Kayıt</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form id="addForm" action="/stock/add" method="post">
+        <div class="modal-body">
+          <input class="form-control mb-2" type="text" name="urun_adi" placeholder="Ürün Adı" required>
+          <input class="form-control mb-2" type="text" name="kategori" placeholder="Kategori" required>
+          <input class="form-control mb-2" type="text" name="marka" placeholder="Marka" required>
+          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
+          <input class="form-control mb-2" type="text" name="lokasyon" placeholder="Lokasyon" required>
+          <input class="form-control mb-2" type="date" name="guncelleme_tarihi" placeholder="Güncelleme Tarihi">
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Ekle</button>
+        </div>
+      </form>
     </div>
-</form>
+  </div>
+</div>
 
 <form action="/stock/upload" method="post" enctype="multipart/form-data" class="mb-4">
     <div class="input-group">

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -3,7 +3,14 @@
 {% block content %}
 <h2>Yazıcı Envanteri</h2>
 
-<button class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#settingsModal">Ayarlar</button>
+<div class="d-flex gap-2 mb-3">
+  <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#settingsModal">
+    <i class="bi bi-gear"></i>
+  </button>
+  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+    <i class="bi bi-plus"></i>
+  </button>
+</div>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -23,18 +30,30 @@
   </div>
 </div>
 
-<form action="/printer/add" method="post" class="mb-4">
-    <div class="row g-2">
-        <div class="col"><input class="form-control" type="text" name="yazici_markasi" placeholder="Yazıcı Markası" required></div>
-        <div class="col"><input class="form-control" type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required></div>
-        <div class="col"><input class="form-control" type="text" name="kullanim_alani" placeholder="Kullanım Alanı" required></div>
-        <div class="col"><input class="form-control" type="text" name="ip_adresi" placeholder="IP Adresi" required></div>
-        <div class="col"><input class="form-control" type="text" name="mac" placeholder="MAC" required></div>
-        <div class="col"><input class="form-control" type="text" name="hostname" placeholder="Hostname" required></div>
-        <div class="col"><input class="form-control" type="text" name="notlar" placeholder="Notlar"></div>
-        <div class="col-12"><button type="submit" class="btn btn-success">Ekle</button></div>
+<div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addModalLabel">Yeni Kayıt</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form id="addForm" action="/printer/add" method="post">
+        <div class="modal-body">
+          <input class="form-control mb-2" type="text" name="yazici_markasi" placeholder="Yazıcı Markası" required>
+          <input class="form-control mb-2" type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
+          <input class="form-control mb-2" type="text" name="kullanim_alani" placeholder="Kullanım Alanı" required>
+          <input class="form-control mb-2" type="text" name="ip_adresi" placeholder="IP Adresi" required>
+          <input class="form-control mb-2" type="text" name="mac" placeholder="MAC" required>
+          <input class="form-control mb-2" type="text" name="hostname" placeholder="Hostname" required>
+          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Ekle</button>
+        </div>
+      </form>
     </div>
-</form>
+  </div>
+</div>
 
 <form action="/printer/upload" method="post" enctype="multipart/form-data" class="mb-4">
     <div class="input-group">


### PR DESCRIPTION
## Summary
- replace text Settings buttons with gear icons and add adjacent green add buttons
- move add-item forms into modals across inventory templates
- load Bootstrap Icons in base template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d4ac7bd8832b844507bde51487c5