### PR TITLE
Add configurable column widths and wrap table text

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,8 @@ from fastapi.staticfiles import StaticFiles
 from io import BytesIO
 import pandas as pd
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel
-from typing import Optional, List
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict
 from datetime import date, timedelta
 from sqlalchemy import create_engine, Column, Integer, String, Date, Text, Boolean, text, inspect
 from sqlalchemy.ext.declarative import declarative_base
@@ -244,6 +244,7 @@ class CreateTableSchema(BaseModel):
 class ColumnSettings(BaseModel):
     order: List[str]
     visible: List[str]
+    widths: Dict[str, int] = Field(default_factory=dict)
 
 class DeleteIds(BaseModel):
     ids: List[int]
@@ -319,6 +320,7 @@ def inventory_page(
     settings = get_user_settings(user.username, table_name)
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
+    widths = settings.get("widths", {})
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "envanter.html",
@@ -327,6 +329,7 @@ def inventory_page(
             "items": items,
             "columns": display_columns,
             "table_name": table_name,
+            "column_widths": widths,
         },
     )
 
@@ -523,6 +526,7 @@ def license_page(
     settings = get_user_settings(user.username, table_name)
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
+    widths = settings.get("widths", {})
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "lisans.html",
@@ -531,6 +535,7 @@ def license_page(
             "licenses": licenses,
             "columns": display_columns,
             "table_name": table_name,
+            "column_widths": widths,
         },
     )
 
@@ -730,6 +735,7 @@ def stock_page(
     settings = get_user_settings(user.username, table_name)
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
+    widths = settings.get("widths", {})
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "stok.html",
@@ -738,6 +744,7 @@ def stock_page(
             "stocks": stocks,
             "columns": display_columns,
             "table_name": table_name,
+            "column_widths": widths,
         },
     )
 
@@ -918,6 +925,7 @@ def printer_page(
     settings = get_user_settings(user.username, table_name)
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
+    widths = settings.get("widths", {})
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "yazici.html",
@@ -926,6 +934,7 @@ def printer_page(
             "printers": printers,
             "columns": display_columns,
             "table_name": table_name,
+            "column_widths": widths,
         },
     )
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,8 +32,8 @@
     .content{
       margin-left:200px; padding:24px;
     }
-    .table-fixed{ table-layout:fixed; width:100%; }
-    .table-fixed td{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .table-fixed{ table-layout:auto; width:100%; }
+    .table-fixed td{ white-space:normal; word-break:break-word; }
   </style>
 </head>
 <body>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -69,14 +69,14 @@
     <tr>
         <th><input type="checkbox" id="select-all"></th>
         {% for col in columns %}
-        <th>{{ col.replace('_', ' ').title() }}</th>
+        <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
     {% for i in items %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ i.id }}"></td>
         {% for col in columns %}
-        <td class="text-truncate" style="max-width:150px;" title="{{ i|attr(col) }}">{{ i|attr(col) }}</td>
+        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ i|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -107,6 +107,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const settings = await settingsRes.json();
     const order = settings.order || allCols;
     const visible = new Set(settings.visible || allCols);
+    const widths = settings.widths || {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -114,7 +115,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
         li.className = 'list-group-item d-flex align-items-center';
         li.draggable = true;
         li.dataset.col = col;
-        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span>${col}</span>`;
+        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span class="flex-grow-1">${col}</span><input type="number" class="form-control form-control-sm ms-2 width-input" style="width:80px" value="${widths[col] || ''}" placeholder="px">`;
         list.appendChild(li);
     });
     let drag;
@@ -133,12 +134,17 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     const items = document.querySelectorAll('#columns-list li');
     const order = Array.from(items).map(li => li.dataset.col);
     const visible = Array.from(items)
-        .filter(li => li.querySelector('input').checked)
+        .filter(li => li.querySelector('input[type="checkbox"]').checked)
         .map(li => li.dataset.col);
+    const widths = {};
+    items.forEach(li => {
+        const val = parseInt(li.querySelector('.width-input').value);
+        if (!isNaN(val)) widths[li.dataset.col] = val;
+    });
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ order, visible })
+        body: JSON.stringify({ order, visible, widths })
     });
     location.reload();
 });

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -69,14 +69,14 @@
     <tr>
         <th><input type="checkbox" id="select-all"></th>
         {% for col in columns %}
-        <th>{{ col.replace('_', ' ').title() }}</th>
+        <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
     {% for l in licenses %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ l.id }}"></td>
         {% for col in columns %}
-        <td class="text-truncate" style="max-width:150px;" title="{{ l|attr(col) }}">{{ l|attr(col) }}</td>
+        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ l|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -107,6 +107,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const settings = await settingsRes.json();
     const order = settings.order || allCols;
     const visible = new Set(settings.visible || allCols);
+    const widths = settings.widths || {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -114,7 +115,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
         li.className = 'list-group-item d-flex align-items-center';
         li.draggable = true;
         li.dataset.col = col;
-        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span>${col}</span>`;
+        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span class="flex-grow-1">${col}</span><input type="number" class="form-control form-control-sm ms-2 width-input" style="width:80px" value="${widths[col] || ''}" placeholder="px">`;
         list.appendChild(li);
     });
     let drag;
@@ -133,12 +134,17 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     const items = document.querySelectorAll('#columns-list li');
     const order = Array.from(items).map(li => li.dataset.col);
     const visible = Array.from(items)
-        .filter(li => li.querySelector('input').checked)
+        .filter(li => li.querySelector('input[type="checkbox"]').checked)
         .map(li => li.dataset.col);
+    const widths = {};
+    items.forEach(li => {
+        const val = parseInt(li.querySelector('.width-input').value);
+        if (!isNaN(val)) widths[li.dataset.col] = val;
+    });
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ order, visible })
+        body: JSON.stringify({ order, visible, widths })
     });
     location.reload();
 });

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -68,14 +68,14 @@
     <tr>
         <th><input type="checkbox" id="select-all"></th>
         {% for col in columns %}
-        <th>{{ col.replace('_', ' ').title() }}</th>
+        <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
     {% for s in stocks %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ s.id }}"></td>
         {% for col in columns %}
-        <td class="text-truncate" style="max-width:150px;" title="{{ s|attr(col) }}">{{ s|attr(col) }}</td>
+        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ s|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -106,6 +106,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const settings = await settingsRes.json();
     const order = settings.order || allCols;
     const visible = new Set(settings.visible || allCols);
+    const widths = settings.widths || {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -113,7 +114,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
         li.className = 'list-group-item d-flex align-items-center';
         li.draggable = true;
         li.dataset.col = col;
-        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span>${col}</span>`;
+        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span class="flex-grow-1">${col}</span><input type="number" class="form-control form-control-sm ms-2 width-input" style="width:80px" value="${widths[col] || ''}" placeholder="px">`;
         list.appendChild(li);
     });
     let drag;
@@ -132,12 +133,17 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     const items = document.querySelectorAll('#columns-list li');
     const order = Array.from(items).map(li => li.dataset.col);
     const visible = Array.from(items)
-        .filter(li => li.querySelector('input').checked)
+        .filter(li => li.querySelector('input[type="checkbox"]').checked)
         .map(li => li.dataset.col);
+    const widths = {};
+    items.forEach(li => {
+        const val = parseInt(li.querySelector('.width-input').value);
+        if (!isNaN(val)) widths[li.dataset.col] = val;
+    });
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ order, visible })
+        body: JSON.stringify({ order, visible, widths })
     });
     location.reload();
 });

--- a/templates/trash.html
+++ b/templates/trash.html
@@ -14,13 +14,13 @@
   </tr>
   {% for i in hardware %}
   <tr>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.demirbas_adi }}">{{ i.demirbas_adi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.marka }}">{{ i.marka }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.model }}">{{ i.model }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.seri_no }}">{{ i.seri_no }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.lokasyon }}">{{ i.lokasyon }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.zimmetli_kisi }}">{{ i.zimmetli_kisi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ i.notlar }}">{{ i.notlar }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.demirbas_adi }}">{{ i.demirbas_adi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.marka }}">{{ i.marka }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.model }}">{{ i.model }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.seri_no }}">{{ i.seri_no }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.lokasyon }}">{{ i.lokasyon }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.zimmetli_kisi }}">{{ i.zimmetli_kisi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ i.notlar }}">{{ i.notlar }}</td>
     <td>
       <form action="/inventory/restore/{{ i.id }}" method="post" style="display:inline;">
         <button type="submit" class="btn btn-success btn-sm">Geri Yükle</button>
@@ -40,13 +40,13 @@
   </tr>
   {% for l in licenses %}
   <tr>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.yazilim_adi }}">{{ l.yazilim_adi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.lisans_anahtari }}">{{ l.lisans_anahtari }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.adet }}">{{ l.adet }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.satin_alma_tarihi }}">{{ l.satin_alma_tarihi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.bitis_tarihi }}">{{ l.bitis_tarihi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.zimmetli_kisi }}">{{ l.zimmetli_kisi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ l.notlar }}">{{ l.notlar }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.yazilim_adi }}">{{ l.yazilim_adi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.lisans_anahtari }}">{{ l.lisans_anahtari }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.adet }}">{{ l.adet }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.satin_alma_tarihi }}">{{ l.satin_alma_tarihi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.bitis_tarihi }}">{{ l.bitis_tarihi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.zimmetli_kisi }}">{{ l.zimmetli_kisi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ l.notlar }}">{{ l.notlar }}</td>
     <td>
       <form action="/license/restore/{{ l.id }}" method="post" style="display:inline;">
         <button type="submit" class="btn btn-success btn-sm">Geri Yükle</button>
@@ -66,13 +66,13 @@
   </tr>
   {% for p in printers %}
   <tr>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.yazici_markasi }}">{{ p.yazici_markasi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.yazici_modeli }}">{{ p.yazici_modeli }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.kullanim_alani }}">{{ p.kullanim_alani }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.ip_adresi }}">{{ p.ip_adresi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.mac }}">{{ p.mac }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.hostname }}">{{ p.hostname }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ p.notlar }}">{{ p.notlar }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.yazici_markasi }}">{{ p.yazici_markasi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.yazici_modeli }}">{{ p.yazici_modeli }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.kullanim_alani }}">{{ p.kullanim_alani }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.ip_adresi }}">{{ p.ip_adresi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.mac }}">{{ p.mac }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.hostname }}">{{ p.hostname }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ p.notlar }}">{{ p.notlar }}</td>
     <td>
       <form action="/printer/restore/{{ p.id }}" method="post" style="display:inline;">
         <button type="submit" class="btn btn-success btn-sm">Geri Yükle</button>
@@ -92,12 +92,12 @@
   </tr>
   {% for s in stocks %}
   <tr>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.urun_adi }}">{{ s.urun_adi }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.kategori }}">{{ s.kategori }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.marka }}">{{ s.marka }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.adet }}">{{ s.adet }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.lokasyon }}">{{ s.lokasyon }}</td>
-    <td class="text-truncate" style="max-width:150px;" title="{{ s.guncelleme_tarihi }}">{{ s.guncelleme_tarihi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.urun_adi }}">{{ s.urun_adi }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.kategori }}">{{ s.kategori }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.marka }}">{{ s.marka }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.adet }}">{{ s.adet }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.lokasyon }}">{{ s.lokasyon }}</td>
+    <td style="white-space: normal; word-break: break-word;" title="{{ s.guncelleme_tarihi }}">{{ s.guncelleme_tarihi }}</td>
     <td>
       <form action="/stock/restore/{{ s.id }}" method="post" style="display:inline;">
         <button type="submit" class="btn btn-success btn-sm">Geri Yükle</button>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -69,14 +69,14 @@
     <tr>
         <th><input type="checkbox" id="select-all"></th>
         {% for col in columns %}
-        <th>{{ col.replace('_', ' ').title() }}</th>
+        <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
     {% for p in printers %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ p.id }}"></td>
         {% for col in columns %}
-        <td class="text-truncate" style="max-width:150px;" title="{{ p|attr(col) }}">{{ p|attr(col) }}</td>
+        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ p|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -107,6 +107,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const settings = await settingsRes.json();
     const order = settings.order || allCols;
     const visible = new Set(settings.visible || allCols);
+    const widths = settings.widths || {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -114,7 +115,7 @@ settingsModal.addEventListener('show.bs.modal', async () => {
         li.className = 'list-group-item d-flex align-items-center';
         li.draggable = true;
         li.dataset.col = col;
-        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span>${col}</span>`;
+        li.innerHTML = `<input class="form-check-input me-2" type="checkbox" ${visible.has(col) ? 'checked' : ''}> <span class="flex-grow-1">${col}</span><input type="number" class="form-control form-control-sm ms-2 width-input" style="width:80px" value="${widths[col] || ''}" placeholder="px">`;
         list.appendChild(li);
     });
     let drag;
@@ -133,12 +134,17 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     const items = document.querySelectorAll('#columns-list li');
     const order = Array.from(items).map(li => li.dataset.col);
     const visible = Array.from(items)
-        .filter(li => li.querySelector('input').checked)
+        .filter(li => li.querySelector('input[type="checkbox"]').checked)
         .map(li => li.dataset.col);
+    const widths = {};
+    items.forEach(li => {
+        const val = parseInt(li.querySelector('.width-input').value);
+        if (!isNaN(val)) widths[li.dataset.col] = val;
+    });
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ order, visible })
+        body: JSON.stringify({ order, visible, widths })
     });
     location.reload();
 });


### PR DESCRIPTION
## Summary
- allow users to specify column widths in table settings
- render table cells with wrapping text instead of truncation
- adjust base styles and trash view to show full content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1efdfea4832b9237478cb85afa3f