### PR TITLE
Add inventory option management and dropdowns

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -55,6 +55,7 @@
       <li><a href="/printer"   class="{% if request.path.startswith('/printer') %}active{% endif %}">Yazıcı Takip</a></li>
       <li><a href="/stock"     class="{% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
       <li><a href="/trash" class="{% if request.path.startswith('/trash') %}active{% endif %}">Çöp Kutusu</a></li>
+      <li><a href="/lists" class="{% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
     </ul>
   </div>
 

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -43,10 +43,18 @@
       <form id="addForm" action="/inventory/add" method="post">
         <div class="modal-body">
           <input class="form-control mb-2" type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required>
-          <input class="form-control mb-2" type="text" name="marka" placeholder="Marka" required>
+          <select class="form-select mb-2" name="marka" required>
+            {% for b in brands %}
+            <option value="{{ b.name }}">{{ b.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="text" name="model" placeholder="Model" required>
           <input class="form-control mb-2" type="text" name="seri_no" placeholder="Seri No" required>
-          <input class="form-control mb-2" type="text" name="lokasyon" placeholder="Lokasyon" required>
+          <select class="form-select mb-2" name="lokasyon" required>
+            {% for l in locations %}
+            <option value="{{ l.name }}">{{ l.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
           <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
         </div>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -42,7 +42,11 @@
       </div>
       <form id="addForm" action="/license/add" method="post">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="yazilim_adi" placeholder="Yazılım Adı" required>
+          <select class="form-select mb-2" name="yazilim_adi" required>
+            {% for s in softwares %}
+            <option value="{{ s.name }}">{{ s.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required>
           <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
           <input class="form-control mb-2" type="date" name="satin_alma_tarihi" placeholder="Satın Alma Tarihi">

--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Envanter Ekleme{% endblock %}
+{% block content %}
+<h2>Envanter Ekleme</h2>
+<div class="row">
+  <div class="col-md-3">
+    <h5>Marka</h5>
+    <ul class="list-group mb-3">
+      {% for b in brands %}
+      <li class="list-group-item">{{ b.name }}</li>
+      {% endfor %}
+    </ul>
+    <form action="/lists/add" method="post" class="d-flex gap-2">
+      <input type="hidden" name="item_type" value="marka">
+      <input class="form-control" type="text" name="name" placeholder="Yeni marka" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+  </div>
+  <div class="col-md-3">
+    <h5>Lokasyon</h5>
+    <ul class="list-group mb-3">
+      {% for l in locations %}
+      <li class="list-group-item">{{ l.name }}</li>
+      {% endfor %}
+    </ul>
+    <form action="/lists/add" method="post" class="d-flex gap-2">
+      <input type="hidden" name="item_type" value="lokasyon">
+      <input class="form-control" type="text" name="name" placeholder="Yeni lokasyon" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+  </div>
+  <div class="col-md-3">
+    <h5>Kategori</h5>
+    <ul class="list-group mb-3">
+      {% for c in categories %}
+      <li class="list-group-item">{{ c.name }}</li>
+      {% endfor %}
+    </ul>
+    <form action="/lists/add" method="post" class="d-flex gap-2">
+      <input type="hidden" name="item_type" value="kategori">
+      <input class="form-control" type="text" name="name" placeholder="Yeni kategori" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+  </div>
+  <div class="col-md-3">
+    <h5>Yazılım</h5>
+    <ul class="list-group mb-3">
+      {% for s in softwares %}
+      <li class="list-group-item">{{ s.name }}</li>
+      {% endfor %}
+    </ul>
+    <form action="/lists/add" method="post" class="d-flex gap-2">
+      <input type="hidden" name="item_type" value="yazilim">
+      <input class="form-control" type="text" name="name" placeholder="Yeni yazılım" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -43,10 +43,22 @@
       <form id="addForm" action="/stock/add" method="post">
         <div class="modal-body">
           <input class="form-control mb-2" type="text" name="urun_adi" placeholder="Ürün Adı" required>
-          <input class="form-control mb-2" type="text" name="kategori" placeholder="Kategori" required>
-          <input class="form-control mb-2" type="text" name="marka" placeholder="Marka" required>
+          <select class="form-select mb-2" name="kategori" required>
+            {% for c in categories %}
+            <option value="{{ c.name }}">{{ c.name }}</option>
+            {% endfor %}
+          </select>
+          <select class="form-select mb-2" name="marka" required>
+            {% for b in brands %}
+            <option value="{{ b.name }}">{{ b.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
-          <input class="form-control mb-2" type="text" name="lokasyon" placeholder="Lokasyon" required>
+          <select class="form-select mb-2" name="lokasyon" required>
+            {% for l in locations %}
+            <option value="{{ l.name }}">{{ l.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="date" name="guncelleme_tarihi" placeholder="Güncelleme Tarihi">
         </div>
         <div class="modal-footer">

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -42,9 +42,17 @@
       </div>
       <form id="addForm" action="/printer/add" method="post">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="yazici_markasi" placeholder="Yazıcı Markası" required>
+          <select class="form-select mb-2" name="yazici_markasi" required>
+            {% for b in brands %}
+            <option value="{{ b.name }}">{{ b.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
-          <input class="form-control mb-2" type="text" name="kullanim_alani" placeholder="Kullanım Alanı" required>
+          <select class="form-select mb-2" name="kullanim_alani" required>
+            {% for l in locations %}
+            <option value="{{ l.name }}">{{ l.name }}</option>
+            {% endfor %}
+          </select>
           <input class="form-control mb-2" type="text" name="ip_adresi" placeholder="IP Adresi" required>
           <input class="form-control mb-2" type="text" name="mac" placeholder="MAC" required>
           <input class="form-control mb-2" type="text" name="hostname" placeholder="Hostname" required>


### PR DESCRIPTION
## Summary
- add LookupItem model and `/lists` routes to manage brand, location, category and software options
- link new "Envanter Ekleme" page in sidebar with forms to add options
- use dropdowns on inventory, license, stock and printer modals populated from these lists

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a30a886f0832b9bb6423762e0477d