### PR TITLE
Add record count labels and improve row editing

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center">
   <h2>Donanım Envanteri</h2>
-  <span class="badge bg-secondary">{{ count }}</span>
+  <span class="badge bg-secondary">{{ count }} kayıt var</span>
 </div>
 
 <div class="d-flex gap-2 mb-3">
@@ -130,7 +130,7 @@
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ i.id }}"></td>
         {% for col in columns %}
-        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ i|attr(col) }}</td>
+        <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ i|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -237,12 +237,11 @@ document.getElementById('edit-selected').addEventListener('click', () => {
         return;
     }
     const row = checked[0].closest('tr');
-    const cells = row.querySelectorAll('td');
     const form = document.getElementById('editForm');
     form.item_id.value = checked[0].value;
-    columns.forEach((col, idx) => {
-        const input = form.querySelector(`[name="${col}"]`);
-        if (input) input.value = cells[idx + 1].innerText.trim();
+    row.querySelectorAll('td[data-col]').forEach(cell => {
+        const input = form.querySelector(`[name="${cell.dataset.col}"]`);
+        if (input) input.value = cell.innerText.trim();
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center">
   <h2>Lisans Envanteri</h2>
-  <span class="badge bg-secondary">{{ count }}</span>
+  <span class="badge bg-secondary">{{ count }} kayıt var</span>
 </div>
 
 <div class="d-flex gap-2 mb-3">
@@ -122,7 +122,7 @@
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ l.id }}"></td>
         {% for col in columns %}
-        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ l|attr(col) }}</td>
+        <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ l|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -229,12 +229,11 @@ document.getElementById('edit-selected').addEventListener('click', () => {
         return;
     }
     const row = checked[0].closest('tr');
-    const cells = row.querySelectorAll('td');
     const form = document.getElementById('editForm');
     form.license_id.value = checked[0].value;
-    columns.forEach((col, idx) => {
-        const input = form.querySelector(`[name="${col}"]`);
-        if (input) input.value = cells[idx + 1].innerText.trim();
+    row.querySelectorAll('td[data-col]').forEach(cell => {
+        const input = form.querySelector(`[name="${cell.dataset.col}"]`);
+        if (input) input.value = cell.innerText.trim();
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center">
   <h2>Stok Takibi</h2>
-  <span class="badge bg-secondary">{{ count }}</span>
+  <span class="badge bg-secondary">{{ count }} kayıt var</span>
 </div>
 
 <div class="d-flex gap-2 mb-3">
@@ -136,7 +136,7 @@
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ s.id }}"></td>
         {% for col in columns %}
-        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ s|attr(col) }}</td>
+        <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ s|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -243,12 +243,11 @@ document.getElementById('edit-selected').addEventListener('click', () => {
         return;
     }
     const row = checked[0].closest('tr');
-    const cells = row.querySelectorAll('td');
     const form = document.getElementById('editForm');
     form.stock_id.value = checked[0].value;
-    columns.forEach((col, idx) => {
-        const input = form.querySelector(`[name="${col}"]`);
-        if (input) input.value = cells[idx + 1].innerText.trim();
+    row.querySelectorAll('td[data-col]').forEach(cell => {
+        const input = form.querySelector(`[name="${cell.dataset.col}"]`);
+        if (input) input.value = cell.innerText.trim();
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center">
   <h2>Yazıcı Envanteri</h2>
-  <span class="badge bg-secondary">{{ count }}</span>
+  <span class="badge bg-secondary">{{ count }} kayıt var</span>
 </div>
 
 <div class="d-flex gap-2 mb-3">
@@ -130,7 +130,7 @@
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ p.id }}"></td>
         {% for col in columns %}
-        <td{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ p|attr(col) }}</td>
+        <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ p|attr(col) }}</td>
         {% endfor %}
     </tr>
     {% endfor %}
@@ -237,12 +237,11 @@ document.getElementById('edit-selected').addEventListener('click', () => {
         return;
     }
     const row = checked[0].closest('tr');
-    const cells = row.querySelectorAll('td');
     const form = document.getElementById('editForm');
     form.printer_id.value = checked[0].value;
-    columns.forEach((col, idx) => {
-        const input = form.querySelector(`[name="${col}"]`);
-        if (input) input.value = cells[idx + 1].innerText.trim();
+    row.querySelectorAll('td[data-col]').forEach(cell => {
+        const input = form.querySelector(`[name="${cell.dataset.col}"]`);
+        if (input) input.value = cell.innerText.trim();
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();


### PR DESCRIPTION
## Summary
- Show "kayıt var" next to the total record count on inventory, stock, license and printer pages
- Populate edit modals with selected row data using `data-col` attributes for reliable editing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a3aa57020832bbb6b2af8e5603f3b