### PR TITLE
Prevent unintended form submissions for edit actions

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -22,10 +22,10 @@
       <li><a class="dropdown-item" href="#" id="export-excel">Dışa Aktar</a></li>
     </ul>
   </div>
-  <button id="edit-selected" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="edit-selected" type="button" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-pencil"></i>
   </button>
-  <button id="delete-selected" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
 </div>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -22,10 +22,10 @@
       <li><a class="dropdown-item" href="#" id="export-excel">Dışa Aktar</a></li>
     </ul>
   </div>
-  <button id="edit-selected" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="edit-selected" type="button" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-pencil"></i>
   </button>
-  <button id="delete-selected" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
 </div>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -22,10 +22,10 @@
       <li><a class="dropdown-item" href="#" id="export-excel">Dışa Aktar</a></li>
     </ul>
   </div>
-  <button id="edit-selected" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="edit-selected" type="button" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-pencil"></i>
   </button>
-  <button id="delete-selected" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
 </div>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -22,10 +22,10 @@
       <li><a class="dropdown-item" href="#" id="export-excel">Dışa Aktar</a></li>
     </ul>
   </div>
-  <button id="edit-selected" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="edit-selected" type="button" class="btn btn-warning" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-pencil"></i>
   </button>
-  <button id="delete-selected" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+  <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
 </div>


### PR DESCRIPTION
## Summary
- Mark edit and delete toolbar buttons as `type="button"` so clicking the yellow pencil reliably triggers the edit modal
- Apply the fix across inventory, license, printer and stock templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a3c8fc300832b84814ff06e8833d1