### PR TITLE
Fix extra closing div in inventory template

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -50,6 +50,7 @@
 </div>
 </div>
 </div>
+</div>
 
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -84,8 +85,6 @@
     </div>
   </div>
 </div>
-</div>
-
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- Properly close settings modal in inventory template and remove redundant div after edit modal
- Verified other templates for unnecessary closing tags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a433e2c44832b8063a452bd583a81