### PR TITLE
Fix mismatched modal divs across templates

### DIFF
--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -44,12 +44,13 @@
       <div class="modal-body">
         <ul id="columns-list" class="list-group"></ul>
       </div>
-      <div class="modal-footer">
-        <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-</div>
-</div>
-</div>
+        <div class="modal-footer">
+          <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -79,7 +80,6 @@
       </form>
     </div>
   </div>
-</div>
 </div>
 
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -44,12 +44,13 @@
       <div class="modal-body">
         <ul id="columns-list" class="list-group"></ul>
       </div>
-      <div class="modal-footer">
-        <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-</div>
-</div>
-</div>
+        <div class="modal-footer">
+          <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -86,7 +87,6 @@
       </form>
     </div>
   </div>
-</div>
 </div>
 
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -44,12 +44,13 @@
       <div class="modal-body">
         <ul id="columns-list" class="list-group"></ul>
       </div>
-      <div class="modal-footer">
-        <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-</div>
-</div>
-</div>
+        <div class="modal-footer">
+          <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
   <div class="modal-dialog">
@@ -83,7 +84,6 @@
       </form>
     </div>
   </div>
-</div>
 </div>
 
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">


### PR DESCRIPTION
## Summary
- close settingsModal containers before rendering editModal in item pages
- remove stray closing divs that broke modal DOM structure

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a4984bf8c832bac7e6b48e09f52a4