### PR TITLE
Use session login and label fields

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -62,21 +62,42 @@
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required>
-          <select class="form-select mb-2" name="marka" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="model" placeholder="Model" required>
-          <input class="form-control mb-2" type="text" name="seri_no" placeholder="Seri No" required>
-          <select class="form-select mb-2" name="lokasyon" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Demirbaş Adı</span>
+            <input class="form-control" type="text" name="demirbas_adi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Marka</span>
+            <select class="form-select" name="marka" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Model</span>
+            <input class="form-control" type="text" name="model" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Seri No</span>
+            <input class="form-control" type="text" name="seri_no" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lokasyon</span>
+            <select class="form-select" name="lokasyon" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Zimmetli Kişi</span>
+            <input class="form-control" type="text" name="zimmetli_kisi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -94,21 +115,42 @@
       </div>
       <form id="addForm" action="/inventory/add" method="post">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="demirbas_adi" placeholder="Demirbaş Adı" required>
-          <select class="form-select mb-2" name="marka" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="model" placeholder="Model" required>
-          <input class="form-control mb-2" type="text" name="seri_no" placeholder="Seri No" required>
-          <select class="form-select mb-2" name="lokasyon" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Demirbaş Adı</span>
+            <input class="form-control" type="text" name="demirbas_adi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Marka</span>
+            <select class="form-select" name="marka" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Model</span>
+            <input class="form-control" type="text" name="model" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Seri No</span>
+            <input class="form-control" type="text" name="seri_no" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lokasyon</span>
+            <select class="form-select" name="lokasyon" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Zimmetli Kişi</span>
+            <input class="form-control" type="text" name="zimmetli_kisi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -62,17 +62,38 @@
       <form id="editForm" action="/license/add" method="post">
         <input type="hidden" name="license_id">
         <div class="modal-body">
-          <select class="form-select mb-2" name="yazilim_adi" required>
-            {% for s in softwares %}
-            <option value="{{ s.name }}">{{ s.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required>
-          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
-          <input class="form-control mb-2" type="date" name="satin_alma_tarihi" placeholder="Satın Alma Tarihi">
-          <input class="form-control mb-2" type="date" name="bitis_tarihi" placeholder="Bitiş Tarihi">
-          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazılım Adı</span>
+            <select class="form-select" name="yazilim_adi" required>
+              {% for s in softwares %}
+              <option value="{{ s.name }}">{{ s.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lisans Anahtarı</span>
+            <input class="form-control" type="text" name="lisans_anahtari" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Adet</span>
+            <input class="form-control" type="number" name="adet" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Satın Alma Tarihi</span>
+            <input class="form-control" type="date" name="satin_alma_tarihi">
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Bitiş Tarihi</span>
+            <input class="form-control" type="date" name="bitis_tarihi">
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Zimmetli Kişi</span>
+            <input class="form-control" type="text" name="zimmetli_kisi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -91,17 +112,38 @@
       </div>
       <form id="addForm" action="/license/add" method="post">
         <div class="modal-body">
-          <select class="form-select mb-2" name="yazilim_adi" required>
-            {% for s in softwares %}
-            <option value="{{ s.name }}">{{ s.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="lisans_anahtari" placeholder="Lisans Anahtarı" required>
-          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
-          <input class="form-control mb-2" type="date" name="satin_alma_tarihi" placeholder="Satın Alma Tarihi">
-          <input class="form-control mb-2" type="date" name="bitis_tarihi" placeholder="Bitiş Tarihi">
-          <input class="form-control mb-2" type="text" name="zimmetli_kisi" placeholder="Zimmetli Kişi" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazılım Adı</span>
+            <select class="form-select" name="yazilim_adi" required>
+              {% for s in softwares %}
+              <option value="{{ s.name }}">{{ s.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lisans Anahtarı</span>
+            <input class="form-control" type="text" name="lisans_anahtari" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Adet</span>
+            <input class="form-control" type="number" name="adet" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Satın Alma Tarihi</span>
+            <input class="form-control" type="date" name="satin_alma_tarihi">
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Bitiş Tarihi</span>
+            <input class="form-control" type="date" name="bitis_tarihi">
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Zimmetli Kişi</span>
+            <input class="form-control" type="text" name="zimmetli_kisi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -62,24 +62,42 @@
       <form id="editForm" action="/stock/add" method="post">
         <input type="hidden" name="stock_id">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="urun_adi" placeholder="Ürün Adı" required>
-          <select class="form-select mb-2" name="kategori" required>
-            {% for c in categories %}
-            <option value="{{ c.name }}">{{ c.name }}</option>
-            {% endfor %}
-          </select>
-          <select class="form-select mb-2" name="marka" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
-          <select class="form-select mb-2" name="lokasyon" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="date" name="guncelleme_tarihi" placeholder="Güncelleme Tarihi">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Ürün Adı</span>
+            <input class="form-control" type="text" name="urun_adi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kategori</span>
+            <select class="form-select" name="kategori" required>
+              {% for c in categories %}
+              <option value="{{ c.name }}">{{ c.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Marka</span>
+            <select class="form-select" name="marka" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Adet</span>
+            <input class="form-control" type="number" name="adet" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lokasyon</span>
+            <select class="form-select" name="lokasyon" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Güncelleme Tarihi</span>
+            <input class="form-control" type="date" name="guncelleme_tarihi">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -98,24 +116,42 @@
       </div>
       <form id="addForm" action="/stock/add" method="post">
         <div class="modal-body">
-          <input class="form-control mb-2" type="text" name="urun_adi" placeholder="Ürün Adı" required>
-          <select class="form-select mb-2" name="kategori" required>
-            {% for c in categories %}
-            <option value="{{ c.name }}">{{ c.name }}</option>
-            {% endfor %}
-          </select>
-          <select class="form-select mb-2" name="marka" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="number" name="adet" placeholder="Adet" required>
-          <select class="form-select mb-2" name="lokasyon" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="date" name="guncelleme_tarihi" placeholder="Güncelleme Tarihi">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Ürün Adı</span>
+            <input class="form-control" type="text" name="urun_adi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kategori</span>
+            <select class="form-select" name="kategori" required>
+              {% for c in categories %}
+              <option value="{{ c.name }}">{{ c.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Marka</span>
+            <select class="form-select" name="marka" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Adet</span>
+            <input class="form-control" type="number" name="adet" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Lokasyon</span>
+            <select class="form-select" name="lokasyon" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Güncelleme Tarihi</span>
+            <input class="form-control" type="date" name="guncelleme_tarihi">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -62,21 +62,42 @@
       <form id="editForm" action="/printer/add" method="post">
         <input type="hidden" name="printer_id">
         <div class="modal-body">
-          <select class="form-select mb-2" name="yazici_markasi" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
-          <select class="form-select mb-2" name="kullanim_alani" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="ip_adresi" placeholder="IP Adresi" required>
-          <input class="form-control mb-2" type="text" name="mac" placeholder="MAC" required>
-          <input class="form-control mb-2" type="text" name="hostname" placeholder="Hostname" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazıcı Markası</span>
+            <select class="form-select" name="yazici_markasi" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazıcı Modeli</span>
+            <input class="form-control" type="text" name="yazici_modeli" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kullanım Alanı</span>
+            <select class="form-select" name="kullanim_alani" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">IP Adresi</span>
+            <input class="form-control" type="text" name="ip_adresi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">MAC</span>
+            <input class="form-control" type="text" name="mac" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Hostname</span>
+            <input class="form-control" type="text" name="hostname" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -95,21 +116,42 @@
       </div>
       <form id="addForm" action="/printer/add" method="post">
         <div class="modal-body">
-          <select class="form-select mb-2" name="yazici_markasi" required>
-            {% for b in brands %}
-            <option value="{{ b.name }}">{{ b.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="yazici_modeli" placeholder="Yazıcı Modeli" required>
-          <select class="form-select mb-2" name="kullanim_alani" required>
-            {% for l in locations %}
-            <option value="{{ l.name }}">{{ l.name }}</option>
-            {% endfor %}
-          </select>
-          <input class="form-control mb-2" type="text" name="ip_adresi" placeholder="IP Adresi" required>
-          <input class="form-control mb-2" type="text" name="mac" placeholder="MAC" required>
-          <input class="form-control mb-2" type="text" name="hostname" placeholder="Hostname" required>
-          <input class="form-control mb-2" type="text" name="notlar" placeholder="Notlar">
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazıcı Markası</span>
+            <select class="form-select" name="yazici_markasi" required>
+              {% for b in brands %}
+              <option value="{{ b.name }}">{{ b.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Yazıcı Modeli</span>
+            <input class="form-control" type="text" name="yazici_modeli" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kullanım Alanı</span>
+            <select class="form-select" name="kullanim_alani" required>
+              {% for l in locations %}
+              <option value="{{ l.name }}">{{ l.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">IP Adresi</span>
+            <input class="form-control" type="text" name="ip_adresi" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">MAC</span>
+            <input class="form-control" type="text" name="mac" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Hostname</span>
+            <input class="form-control" type="text" name="hostname" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Notlar</span>
+            <input class="form-control" type="text" name="notlar">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>


### PR DESCRIPTION
## Summary
- Use session-based auth so login occurs once and applies to all pages
- Show column labels to the left of inputs in add/edit forms across inventory, license, printer, and stock templates

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4b41daa8832bbf6900b79cbde49b