### PR TITLE
Add dashboard for factories and recent operations

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,7 @@
   <div class="sidebar">
     <img src="/image/onurum.png" alt="Onurum" class="sidebar-logo"style="width: 150px">
     <ul>
+      <li><a href="/home" class="{% if request.path.startswith('/home') %}active{% endif %}">Ana Sayfa</a></li>
       <li><a href="/inventory" class="{% if request.path.startswith('/inventory') %}active{% endif %}">Envanter Takip</a></li>
       <li><a href="/license"   class="{% if request.path.startswith('/license') %}active{% endif %}">Lisans Takip</a></li>
       <li><a href="/printer"   class="{% if request.path.startswith('/printer') %}active{% endif %}">Yazıcı Takip</a></li>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,5 +1,36 @@
 {% extends "base.html" %}
 {% block title %}Ana Sayfa{% endblock %}
 {% block content %}
-<p>Menüden bir seçenek seçiniz.</p>
+<h1>Fabrika Envanteri</h1>
+<div class="row">
+  {% for factory, categories in factories.items() %}
+  <div class="col-md-4 mb-3">
+    <div class="card">
+      <div class="card-header">{{ factory }}</div>
+      <ul class="list-group list-group-flush">
+        {% for cat in categories %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          {{ cat.kategori }}
+          <span class="badge bg-primary rounded-pill">{{ cat.adet }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<div class="mt-4">
+  <h2>Son İşlemler</h2>
+  <div class="card">
+    <ul class="list-group list-group-flush">
+      {% for item in recent %}
+      <li class="list-group-item">
+        {{ item.guncelleme_tarihi }} - {{ item.urun_adi }} ({{ item.kategori }}) {{ item.adet }} adet
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Add Ana Sayfa link to sidebar
- Show factory category counts on home page
- Display recent stock updates

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4ef5b0bc832b8b886690035adbea