### PR TITLE
Add admin user management with secure logout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-multipart
 pandas
 xlrd==2.0.1
 openpyxl
+passlib[bcrypt]

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Admin Paneli{% endblock %}
+{% block content %}
+<h2>Kullanıcı Yönetimi</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post" action="/admin/create" class="mb-3">
+  <div class="mb-3">
+    <input type="text" name="username" class="form-control" placeholder="Kullanıcı Adı" required>
+  </div>
+  <div class="mb-3">
+    <input type="password" name="password" class="form-control" placeholder="Şifre" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Ekle</button>
+</form>
+<table class="table">
+  <thead>
+    <tr><th>Kullanıcı Adı</th><th>Admin</th></tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.username }}</td>
+      <td>{{ "Evet" if u.is_admin else "Hayır" }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,7 @@
       margin:10px; border-radius:4px;
     }
     .sidebar ul{
-      list-style:none; margin:0; padding:0;
+      list-style:none; margin:0; padding:0; flex-grow:1;
     }
     .sidebar li{}
     .sidebar a{
@@ -57,7 +57,9 @@
       <li><a href="/stock"     class="{% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
       <li><a href="/trash" class="{% if request.path.startswith('/trash') %}active{% endif %}">Çöp Kutusu</a></li>
       <li><a href="/lists" class="{% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
+      <li><a href="/admin" class="{% if request.path.startswith('/admin') %}active{% endif %}">Admin Paneli</a></li>
     </ul>
+    <a href="/logout" class="text-center py-3" title="Çıkış"><i class="bi bi-door-closed-fill text-danger" style="font-size:1.5rem;"></i></a>
   </div>
 
   <div class="content">


### PR DESCRIPTION
## Summary
- Seed database with a hashed default admin user and switch authentication to bcrypt
- Provide an admin panel to add new users and a logout endpoint
- Add sidebar links for the admin panel and a red door logout icon

## Testing
- `pip install passlib[bcrypt]`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a51862080832b853efbdb9c6860f7