### PR TITLE
Force password update on first login

### DIFF
--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Şifre Değiştir</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f9;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .login-container {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            text-align: center;
+            width: 300px;
+        }
+        .login-container h2 {
+            margin-top: 0;
+        }
+        .login-container input {
+            width: 100%;
+            padding: 0.5rem;
+            margin: 0.5rem 0;
+            box-sizing: border-box;
+        }
+        .login-container button {
+            width: 100%;
+            padding: 0.5rem;
+            background-color: #007bff;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .login-container button:hover {
+            background-color: #0056b3;
+        }
+        .error {
+            color: red;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h2>Şifre Değiştir</h2>
+        {% if error %}
+        <p class="error">{{ error }}</p>
+        {% endif %}
+        <form action="/change-password" method="post">
+            <input type="password" name="old_password" placeholder="Eski Şifre" required>
+            <input type="password" name="new_password" placeholder="Yeni Şifre" required>
+            <input type="password" name="confirm_password" placeholder="Yeni Şifre Tekrar" required>
+            <button type="submit">Güncelle</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `must_change_password` flag to users and ensure default admin requires a password update on first login
- Redirect users to a new change-password page until they update their password
- Require admin-created users to update their passwords on first login

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a573ca364832bb8bed007626186d3