### PR TITLE
Add profile page and hide admin panel for non-admin users

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -10,16 +10,28 @@
   <div class="mb-3">
     <input type="password" name="password" class="form-control" placeholder="Şifre" required>
   </div>
+  <div class="mb-3">
+    <input type="text" name="first_name" class="form-control" placeholder="İsim">
+  </div>
+  <div class="mb-3">
+    <input type="text" name="last_name" class="form-control" placeholder="Soyisim">
+  </div>
+  <div class="mb-3">
+    <input type="email" name="email" class="form-control" placeholder="Mail Adresi">
+  </div>
   <button type="submit" class="btn btn-primary">Ekle</button>
 </form>
 <table class="table">
   <thead>
-    <tr><th>Kullanıcı Adı</th><th>Admin</th><th>İşlem</th></tr>
+    <tr><th>Kullanıcı Adı</th><th>İsim</th><th>Soyisim</th><th>Mail</th><th>Admin</th><th>İşlem</th></tr>
   </thead>
   <tbody>
     {% for u in users %}
     <tr>
       <td>{{ u.username }}</td>
+      <td>{{ u.first_name }}</td>
+      <td>{{ u.last_name }}</td>
+      <td>{{ u.email }}</td>
       <td>{{ "Evet" if u.is_admin else "Hayır" }}</td>
       <td>
         {% if not u.is_admin %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,8 +56,11 @@
       <li><a href="/printer"   class="{% if request.path.startswith('/printer') %}active{% endif %}">Yazıcı Takip</a></li>
       <li><a href="/stock"     class="{% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
       <li><a href="/trash" class="{% if request.path.startswith('/trash') %}active{% endif %}">Çöp Kutusu</a></li>
+      <li><a href="/profile" class="{% if request.path.startswith('/profile') %}active{% endif %}">Profil</a></li>
       <li><a href="/lists" class="{% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
+      {% if request.session.get('is_admin') %}
       <li><a href="/admin" class="{% if request.path.startswith('/admin') %}active{% endif %}">Admin Paneli</a></li>
+      {% endif %}
     </ul>
     <a href="/logout" class="text-center py-3" title="Çıkış"><i class="bi bi-door-closed-fill text-danger" style="font-size:1.5rem;"></i></a>
   </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Profil{% endblock %}
+{% block content %}
+<h2>Profil Bilgileri</h2>
+<div class="mb-2"><strong>İsim:</strong> {{ user.first_name }}</div>
+<div class="mb-2"><strong>Soyisim:</strong> {{ user.last_name }}</div>
+<div class="mb-2"><strong>Mail:</strong> {{ user.email }}</div>
+<a href="/change-password" class="btn btn-primary mt-3">Şifre Değiştir</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Expand user model with name and email fields and migrate database
- Store profile details in session and add profile page with password change link
- Hide admin menu for non-admin users and extend admin user creation form

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5b74a420832b8168b6b54a4e9ae2