### PR TITLE
Expand inventory, license and stock tracking columns

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -63,42 +63,19 @@
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
         <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Demirbaş Adı</span>
-            <input class="form-control" type="text" name="demirbas_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Marka</span>
-            <select class="form-select" name="marka" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Model</span>
-            <input class="form-control" type="text" name="model" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Seri No</span>
-            <input class="form-control" type="text" name="seri_no" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lokasyon</span>
-            <select class="form-select" name="lokasyon" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Zimmetli Kişi</span>
-            <input class="form-control" type="text" name="zimmetli_kisi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
+          <div class="input-group mb-2"><span class="input-group-text">No</span><input class="form-control" type="text" name="no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Fabrika</span><input class="form-control" type="text" name="fabrika" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Blok</span><input class="form-control" type="text" name="blok" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Departman</span><input class="form-control" type="text" name="departman" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Donanım Tipi</span><input class="form-control" type="text" name="donanim_tipi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Bilgisayar Adı</span><input class="form-control" type="text" name="bilgisayar_adi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Marka</span><input class="form-control" type="text" name="marka" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Model</span><input class="form-control" type="text" name="model" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Seri No</span><input class="form-control" type="text" name="seri_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Sorumlu Personel</span><input class="form-control" type="text" name="sorumlu_personel" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Kullanım Alanı</span><input class="form-control" type="text" name="kullanim_alani" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Bağlı Olduğu Makina No</span><input class="form-control" type="text" name="bagli_makina_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Notlar</span><input class="form-control" type="text" name="notlar"></div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -116,42 +93,19 @@
       </div>
       <form id="addForm" action="/inventory/add" method="post">
         <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Demirbaş Adı</span>
-            <input class="form-control" type="text" name="demirbas_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Marka</span>
-            <select class="form-select" name="marka" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Model</span>
-            <input class="form-control" type="text" name="model" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Seri No</span>
-            <input class="form-control" type="text" name="seri_no" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lokasyon</span>
-            <select class="form-select" name="lokasyon" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Zimmetli Kişi</span>
-            <input class="form-control" type="text" name="zimmetli_kisi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
+          <div class="input-group mb-2"><span class="input-group-text">No</span><input class="form-control" type="text" name="no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Fabrika</span><input class="form-control" type="text" name="fabrika" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Blok</span><input class="form-control" type="text" name="blok" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Departman</span><input class="form-control" type="text" name="departman" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Donanım Tipi</span><input class="form-control" type="text" name="donanim_tipi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Bilgisayar Adı</span><input class="form-control" type="text" name="bilgisayar_adi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Marka</span><input class="form-control" type="text" name="marka" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Model</span><input class="form-control" type="text" name="model" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Seri No</span><input class="form-control" type="text" name="seri_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Sorumlu Personel</span><input class="form-control" type="text" name="sorumlu_personel" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Kullanım Alanı</span><input class="form-control" type="text" name="kullanim_alani" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Bağlı Olduğu Makina No</span><input class="form-control" type="text" name="bagli_makina_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Notlar</span><input class="form-control" type="text" name="notlar"></div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -64,32 +64,28 @@
         <input type="hidden" name="license_id">
         <div class="modal-body">
           <div class="input-group mb-2">
+            <span class="input-group-text">Departman</span>
+            <input class="form-control" type="text" name="departman" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kullanıcı</span>
+            <input class="form-control" type="text" name="kullanici" required>
+          </div>
+          <div class="input-group mb-2">
             <span class="input-group-text">Yazılım Adı</span>
-            <select class="form-select" name="yazilim_adi" required>
-              {% for s in softwares %}
-              <option value="{{ s.name }}">{{ s.name }}</option>
-              {% endfor %}
-            </select>
+            <input class="form-control" type="text" name="yazilim_adi" required>
           </div>
           <div class="input-group mb-2">
             <span class="input-group-text">Lisans Anahtarı</span>
             <input class="form-control" type="text" name="lisans_anahtari" required>
           </div>
           <div class="input-group mb-2">
-            <span class="input-group-text">Adet</span>
-            <input class="form-control" type="number" name="adet" required>
+            <span class="input-group-text">Bulunduğu Mail Adresi</span>
+            <input class="form-control" type="text" name="mail_adresi" required>
           </div>
           <div class="input-group mb-2">
-            <span class="input-group-text">Satın Alma Tarihi</span>
-            <input class="form-control" type="date" name="satin_alma_tarihi">
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Bitiş Tarihi</span>
-            <input class="form-control" type="date" name="bitis_tarihi">
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Zimmetli Kişi</span>
-            <input class="form-control" type="text" name="zimmetli_kisi" required>
+            <span class="input-group-text">Envanter No</span>
+            <input class="form-control" type="text" name="envanter_no" required>
           </div>
           <div class="input-group mb-2">
             <span class="input-group-text">Notlar</span>
@@ -114,32 +110,28 @@
       <form id="addForm" action="/license/add" method="post">
         <div class="modal-body">
           <div class="input-group mb-2">
+            <span class="input-group-text">Departman</span>
+            <input class="form-control" type="text" name="departman" required>
+          </div>
+          <div class="input-group mb-2">
+            <span class="input-group-text">Kullanıcı</span>
+            <input class="form-control" type="text" name="kullanici" required>
+          </div>
+          <div class="input-group mb-2">
             <span class="input-group-text">Yazılım Adı</span>
-            <select class="form-select" name="yazilim_adi" required>
-              {% for s in softwares %}
-              <option value="{{ s.name }}">{{ s.name }}</option>
-              {% endfor %}
-            </select>
+            <input class="form-control" type="text" name="yazilim_adi" required>
           </div>
           <div class="input-group mb-2">
             <span class="input-group-text">Lisans Anahtarı</span>
             <input class="form-control" type="text" name="lisans_anahtari" required>
           </div>
           <div class="input-group mb-2">
-            <span class="input-group-text">Adet</span>
-            <input class="form-control" type="number" name="adet" required>
+            <span class="input-group-text">Bulunduğu Mail Adresi</span>
+            <input class="form-control" type="text" name="mail_adresi" required>
           </div>
           <div class="input-group mb-2">
-            <span class="input-group-text">Satın Alma Tarihi</span>
-            <input class="form-control" type="date" name="satin_alma_tarihi">
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Bitiş Tarihi</span>
-            <input class="form-control" type="date" name="bitis_tarihi">
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Zimmetli Kişi</span>
-            <input class="form-control" type="text" name="zimmetli_kisi" required>
+            <span class="input-group-text">Envanter No</span>
+            <input class="form-control" type="text" name="envanter_no" required>
           </div>
           <div class="input-group mb-2">
             <span class="input-group-text">Notlar</span>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -28,6 +28,7 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
+  <a class="btn btn-info" href="/stock/status" style="height:40px;display:flex;align-items:center;">Stok Durumu</a>
   <input id="search-input" type="text" class="form-control ms-auto" placeholder="Ara..." style="max-width: 200px;">
 </div>
 
@@ -63,42 +64,14 @@
       <form id="editForm" action="/stock/add" method="post">
         <input type="hidden" name="stock_id">
         <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Ürün Adı</span>
-            <input class="form-control" type="text" name="urun_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kategori</span>
-            <select class="form-select" name="kategori" required>
-              {% for c in categories %}
-              <option value="{{ c.name }}">{{ c.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Marka</span>
-            <select class="form-select" name="marka" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Adet</span>
-            <input class="form-control" type="number" name="adet" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lokasyon</span>
-            <select class="form-select" name="lokasyon" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Güncelleme Tarihi</span>
-            <input class="form-control" type="date" name="guncelleme_tarihi">
-          </div>
+          <div class="input-group mb-2"><span class="input-group-text">Ürün Adı</span><input class="form-control" type="text" name="urun_adi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">İşlem</span><select class="form-select" name="islem" required><option value="giriş">giriş</option><option value="çıkış">çıkış</option><option value="talep">talep</option></select></div>
+          <div class="input-group mb-2"><span class="input-group-text">Adet</span><input class="form-control" type="number" name="adet" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Tarih</span><input class="form-control" type="date" name="tarih"></div>
+          <div class="input-group mb-2"><span class="input-group-text">Lokasyon</span><input class="form-control" type="text" name="lokasyon" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">IFS No</span><input class="form-control" type="text" name="ifs_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Açıklama</span><input class="form-control" type="text" name="aciklama"></div>
+          <div class="input-group mb-2"><span class="input-group-text">İşlem Yapan</span><input class="form-control" type="text" name="islem_yapan" required></div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -117,42 +90,14 @@
       </div>
       <form id="addForm" action="/stock/add" method="post">
         <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Ürün Adı</span>
-            <input class="form-control" type="text" name="urun_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kategori</span>
-            <select class="form-select" name="kategori" required>
-              {% for c in categories %}
-              <option value="{{ c.name }}">{{ c.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Marka</span>
-            <select class="form-select" name="marka" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Adet</span>
-            <input class="form-control" type="number" name="adet" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lokasyon</span>
-            <select class="form-select" name="lokasyon" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Güncelleme Tarihi</span>
-            <input class="form-control" type="date" name="guncelleme_tarihi">
-          </div>
+          <div class="input-group mb-2"><span class="input-group-text">Ürün Adı</span><input class="form-control" type="text" name="urun_adi" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">İşlem</span><select class="form-select" name="islem" required><option value="giriş">giriş</option><option value="çıkış">çıkış</option><option value="talep">talep</option></select></div>
+          <div class="input-group mb-2"><span class="input-group-text">Adet</span><input class="form-control" type="number" name="adet" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Tarih</span><input class="form-control" type="date" name="tarih"></div>
+          <div class="input-group mb-2"><span class="input-group-text">Lokasyon</span><input class="form-control" type="text" name="lokasyon" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">IFS No</span><input class="form-control" type="text" name="ifs_no" required></div>
+          <div class="input-group mb-2"><span class="input-group-text">Açıklama</span><input class="form-control" type="text" name="aciklama"></div>
+          <div class="input-group mb-2"><span class="input-group-text">İşlem Yapan</span><input class="form-control" type="text" name="islem_yapan" required></div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/stok_durumu.html
+++ b/templates/stok_durumu.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Stok Durumu{% endblock %}
+{% block content %}
+<h2>Stok Durumu</h2>
+<table class="table table-striped">
+  <tr><th>Ürün Adı</th><th>Stok</th></tr>
+  {% for name, qty in summary %}
+  <tr><td>{{ name }}</td><td>{{ qty }}</td></tr>
+  {% endfor %}
+</table>
+<a class="btn btn-secondary" href="/stock">Geri Dön</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- broaden hardware, license and stock models to cover department info and transaction details
- add stock status view and button for summarized counts
- update inventory, license and stock forms to match new schema

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689ae03e1444832b9e3585a1b7cb1564