### PR TITLE
Remove per-column search inputs and enable admin role assignment

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -19,6 +19,10 @@
   <div class="mb-3">
     <input type="email" name="email" class="form-control" placeholder="Mail Adresi">
   </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="is_admin" id="is_admin">
+    <label class="form-check-label" for="is_admin">Admin</label>
+  </div>
   <button type="submit" class="btn btn-primary">Ekle</button>
 </form>
 <table class="table">
@@ -35,6 +39,9 @@
       <td>{{ "Evet" if u.is_admin else "Hayır" }}</td>
       <td>
         {% if not u.is_admin %}
+        <form method="post" action="/admin/make_admin/{{ u.id }}" style="display:inline">
+          <button type="submit" class="btn btn-secondary btn-sm">Admin Yap</button>
+        </form>
         <form method="post" action="/admin/delete/{{ u.id }}" style="display:inline">
           <button type="submit" class="btn btn-danger btn-sm">Sil</button>
         </form>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -122,12 +122,6 @@
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
-    <tr>
-        <th></th>
-        {% for col in columns %}
-        <th><input type="text" class="form-control form-control-sm column-filter" data-col="{{ col }}" value="{{ filters.get(col, '') }}"></th>
-        {% endfor %}
-    </tr>
     {% for i in items %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ i.id }}"></td>
@@ -160,7 +154,7 @@ const tableName = "{{ table_name }}";
 let currentSettings = {};
 fetch(`/column-settings?table_name=${tableName}`)
     .then(r => r.json())
-    .then(s => { currentSettings = s; if (!currentSettings.filters) currentSettings.filters = {}; });
+    .then(s => { currentSettings = s; });
 const settingsModal = document.getElementById('settingsModal');
 settingsModal.addEventListener('show.bs.modal', async () => {
     const res = await fetch(`/table-columns?table_name=${tableName}`);
@@ -171,7 +165,6 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const visible = new Set(settings.visible || allCols);
     const widths = settings.widths || {};
     currentSettings = settings;
-    if (!currentSettings.filters) currentSettings.filters = {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -208,27 +201,13 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     currentSettings.order = order;
     currentSettings.visible = visible;
     currentSettings.widths = widths;
+    delete currentSettings.filters;
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(currentSettings)
     });
     location.reload();
-});
-
-document.querySelectorAll('.column-filter').forEach(input => {
-    input.addEventListener('change', async () => {
-        const col = input.dataset.col;
-        const val = input.value.trim();
-        if (val) currentSettings.filters[col] = val;
-        else delete currentSettings.filters[col];
-        await fetch(`/column-settings?table_name=${tableName}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(currentSettings)
-        });
-        location.reload();
-    });
 });
 
 const editButton = document.getElementById('edit-selected');

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -153,12 +153,6 @@
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
-    <tr>
-        <th></th>
-        {% for col in columns %}
-        <th><input type="text" class="form-control form-control-sm column-filter" data-col="{{ col }}" value="{{ filters.get(col, '') }}"></th>
-        {% endfor %}
-    </tr>
     {% for l in licenses %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ l.id }}"></td>
@@ -191,7 +185,7 @@ const tableName = "{{ table_name }}";
 let currentSettings = {};
 fetch(`/column-settings?table_name=${tableName}`)
     .then(r => r.json())
-    .then(s => { currentSettings = s; if (!currentSettings.filters) currentSettings.filters = {}; });
+    .then(s => { currentSettings = s; });
 const settingsModal = document.getElementById('settingsModal');
 settingsModal.addEventListener('show.bs.modal', async () => {
     const res = await fetch(`/table-columns?table_name=${tableName}`);
@@ -202,7 +196,6 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const visible = new Set(settings.visible || allCols);
     const widths = settings.widths || {};
     currentSettings = settings;
-    if (!currentSettings.filters) currentSettings.filters = {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -239,27 +232,13 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     currentSettings.order = order;
     currentSettings.visible = visible;
     currentSettings.widths = widths;
+    delete currentSettings.filters;
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(currentSettings)
     });
     location.reload();
-});
-
-document.querySelectorAll('.column-filter').forEach(input => {
-    input.addEventListener('change', async () => {
-        const col = input.dataset.col;
-        const val = input.value.trim();
-        if (val) currentSettings.filters[col] = val;
-        else delete currentSettings.filters[col];
-        await fetch(`/column-settings?table_name=${tableName}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(currentSettings)
-        });
-        location.reload();
-    });
 });
 
 const editButton = document.getElementById('edit-selected');

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -114,12 +114,6 @@
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
-    <tr>
-        <th></th>
-        {% for col in columns %}
-        <th><input type="text" class="form-control form-control-sm column-filter" data-col="{{ col }}" value="{{ filters.get(col, '') }}"></th>
-        {% endfor %}
-    </tr>
     {% for s in stocks %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ s.id }}"></td>
@@ -152,7 +146,7 @@ const tableName = "{{ table_name }}";
 let currentSettings = {};
 fetch(`/column-settings?table_name=${tableName}`)
     .then(r => r.json())
-    .then(s => { currentSettings = s; if (!currentSettings.filters) currentSettings.filters = {}; });
+    .then(s => { currentSettings = s; });
 const settingsModal = document.getElementById('settingsModal');
 settingsModal.addEventListener('show.bs.modal', async () => {
     const res = await fetch(`/table-columns?table_name=${tableName}`);
@@ -163,7 +157,6 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const visible = new Set(settings.visible || allCols);
     const widths = settings.widths || {};
     currentSettings = settings;
-    if (!currentSettings.filters) currentSettings.filters = {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -198,29 +191,15 @@ document.getElementById('save-settings').addEventListener('click', async () => {
         if (!isNaN(val)) widths[li.dataset.col] = val;
     });
     currentSettings.order = order;
-    currentSettings.visible = visible;
-    currentSettings.widths = widths;
+   currentSettings.visible = visible;
+   currentSettings.widths = widths;
+    delete currentSettings.filters;
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(currentSettings)
     });
     location.reload();
-});
-
-document.querySelectorAll('.column-filter').forEach(input => {
-    input.addEventListener('change', async () => {
-        const col = input.dataset.col;
-        const val = input.value.trim();
-        if (val) currentSettings.filters[col] = val;
-        else delete currentSettings.filters[col];
-        await fetch(`/column-settings?table_name=${tableName}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(currentSettings)
-        });
-        location.reload();
-    });
 });
 
 const editButton = document.getElementById('edit-selected');

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -169,12 +169,6 @@
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
     </tr>
-    <tr>
-        <th></th>
-        {% for col in columns %}
-        <th><input type="text" class="form-control form-control-sm column-filter" data-col="{{ col }}" value="{{ filters.get(col, '') }}"></th>
-        {% endfor %}
-    </tr>
     {% for p in printers %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ p.id }}"></td>
@@ -207,7 +201,7 @@ const tableName = "{{ table_name }}";
 let currentSettings = {};
 fetch(`/column-settings?table_name=${tableName}`)
     .then(r => r.json())
-    .then(s => { currentSettings = s; if (!currentSettings.filters) currentSettings.filters = {}; });
+    .then(s => { currentSettings = s; });
 const settingsModal = document.getElementById('settingsModal');
 settingsModal.addEventListener('show.bs.modal', async () => {
     const res = await fetch(`/table-columns?table_name=${tableName}`);
@@ -218,7 +212,6 @@ settingsModal.addEventListener('show.bs.modal', async () => {
     const visible = new Set(settings.visible || allCols);
     const widths = settings.widths || {};
     currentSettings = settings;
-    if (!currentSettings.filters) currentSettings.filters = {};
     const list = document.getElementById('columns-list');
     list.innerHTML = '';
     order.forEach(col => {
@@ -255,27 +248,13 @@ document.getElementById('save-settings').addEventListener('click', async () => {
     currentSettings.order = order;
     currentSettings.visible = visible;
     currentSettings.widths = widths;
+    delete currentSettings.filters;
     await fetch(`/column-settings?table_name=${tableName}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(currentSettings)
     });
     location.reload();
-});
-
-document.querySelectorAll('.column-filter').forEach(input => {
-    input.addEventListener('change', async () => {
-        const col = input.dataset.col;
-        const val = input.value.trim();
-        if (val) currentSettings.filters[col] = val;
-        else delete currentSettings.filters[col];
-        await fetch(`/column-settings?table_name=${tableName}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(currentSettings)
-        });
-        location.reload();
-    });
 });
 
 const editButton = document.getElementById('edit-selected');


### PR DESCRIPTION
## Summary
- Drop column-specific filter inputs on inventory, license, stock, and printer pages, keeping only the global search box
- Support granting admin rights via admin panel with checkbox on user creation and "Admin Yap" action
- Simplify backend by removing column filter processing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689aef445a10832b92b66f41ab41fcb2