### PR TITLE
Clear modal-body content across templates

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -42,9 +42,7 @@
         <h5 class="modal-title" id="settingsModalLabel">Kolon Ayarları</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <div class="modal-body">
-        <ul id="columns-list" class="list-group"></ul>
-      </div>
+        <div class="modal-body"></div>
       <div class="modal-footer">
         <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
@@ -62,21 +60,7 @@
       </div>
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
-        <div class="modal-body">
-          <div class="input-group mb-2"><span class="input-group-text">No</span><input class="form-control" type="text" name="no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Fabrika</span><input class="form-control" type="text" name="fabrika" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Blok</span><input class="form-control" type="text" name="blok" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Departman</span><input class="form-control" type="text" name="departman" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Donanım Tipi</span><input class="form-control" type="text" name="donanim_tipi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Bilgisayar Adı</span><input class="form-control" type="text" name="bilgisayar_adi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Marka</span><input class="form-control" type="text" name="marka" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Model</span><input class="form-control" type="text" name="model" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Seri No</span><input class="form-control" type="text" name="seri_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Sorumlu Personel</span><input class="form-control" type="text" name="sorumlu_personel" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Kullanım Alanı</span><input class="form-control" type="text" name="kullanim_alani" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Bağlı Olduğu Makina No</span><input class="form-control" type="text" name="bagli_makina_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Notlar</span><input class="form-control" type="text" name="notlar"></div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -92,21 +76,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/inventory/add" method="post">
-        <div class="modal-body">
-          <div class="input-group mb-2"><span class="input-group-text">No</span><input class="form-control" type="text" name="no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Fabrika</span><input class="form-control" type="text" name="fabrika" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Blok</span><input class="form-control" type="text" name="blok" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Departman</span><input class="form-control" type="text" name="departman" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Donanım Tipi</span><input class="form-control" type="text" name="donanim_tipi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Bilgisayar Adı</span><input class="form-control" type="text" name="bilgisayar_adi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Marka</span><input class="form-control" type="text" name="marka" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Model</span><input class="form-control" type="text" name="model" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Seri No</span><input class="form-control" type="text" name="seri_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Sorumlu Personel</span><input class="form-control" type="text" name="sorumlu_personel" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Kullanım Alanı</span><input class="form-control" type="text" name="kullanim_alani" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Bağlı Olduğu Makina No</span><input class="form-control" type="text" name="bagli_makina_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Notlar</span><input class="form-control" type="text" name="notlar"></div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -138,7 +108,7 @@
       <div class="modal-header">
         <h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Silme Onayı</h5>
       </div>
-      <div class="modal-body">Seçili kayıtları silmek istediğinizden emin misiniz?</div>
+        <div class="modal-body"></div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
         <button id="confirm-delete" type="button" class="btn btn-danger">Sil</button>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -42,9 +42,7 @@
         <h5 class="modal-title" id="settingsModalLabel">Kolon Ayarları</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <div class="modal-body">
-        <ul id="columns-list" class="list-group"></ul>
-      </div>
+        <div class="modal-body"></div>
         <div class="modal-footer">
           <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
@@ -62,36 +60,7 @@
       </div>
       <form id="editForm" action="/license/add" method="post">
         <input type="hidden" name="license_id">
-        <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Departman</span>
-            <input class="form-control" type="text" name="departman" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kullanıcı</span>
-            <input class="form-control" type="text" name="kullanici" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazılım Adı</span>
-            <input class="form-control" type="text" name="yazilim_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lisans Anahtarı</span>
-            <input class="form-control" type="text" name="lisans_anahtari" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Bulunduğu Mail Adresi</span>
-            <input class="form-control" type="text" name="mail_adresi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Envanter No</span>
-            <input class="form-control" type="text" name="envanter_no" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -108,36 +77,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/license/add" method="post">
-        <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Departman</span>
-            <input class="form-control" type="text" name="departman" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kullanıcı</span>
-            <input class="form-control" type="text" name="kullanici" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazılım Adı</span>
-            <input class="form-control" type="text" name="yazilim_adi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Lisans Anahtarı</span>
-            <input class="form-control" type="text" name="lisans_anahtari" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Bulunduğu Mail Adresi</span>
-            <input class="form-control" type="text" name="mail_adresi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Envanter No</span>
-            <input class="form-control" type="text" name="envanter_no" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -179,7 +119,7 @@
       <div class="modal-header">
         <h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Silme Onayı</h5>
       </div>
-      <div class="modal-body">Seçili kayıtları silmek istediğinizden emin misiniz?</div>
+        <div class="modal-body"></div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
         <button id="confirm-delete" type="button" class="btn btn-danger">Sil</button>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -43,9 +43,7 @@
         <h5 class="modal-title" id="settingsModalLabel">Kolon Ayarları</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <div class="modal-body">
-        <ul id="columns-list" class="list-group"></ul>
-      </div>
+        <div class="modal-body"></div>
         <div class="modal-footer">
           <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
@@ -63,16 +61,7 @@
       </div>
       <form id="editForm" action="/stock/add" method="post">
         <input type="hidden" name="stock_id">
-        <div class="modal-body">
-          <div class="input-group mb-2"><span class="input-group-text">Ürün Adı</span><input class="form-control" type="text" name="urun_adi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">İşlem</span><select class="form-select" name="islem" required><option value="giriş">giriş</option><option value="çıkış">çıkış</option><option value="talep">talep</option></select></div>
-          <div class="input-group mb-2"><span class="input-group-text">Adet</span><input class="form-control" type="number" name="adet" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Tarih</span><input class="form-control" type="date" name="tarih"></div>
-          <div class="input-group mb-2"><span class="input-group-text">Lokasyon</span><input class="form-control" type="text" name="lokasyon" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">IFS No</span><input class="form-control" type="text" name="ifs_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Açıklama</span><input class="form-control" type="text" name="aciklama"></div>
-          <div class="input-group mb-2"><span class="input-group-text">İşlem Yapan</span><input class="form-control" type="text" name="islem_yapan" required></div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -89,16 +78,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/stock/add" method="post">
-        <div class="modal-body">
-          <div class="input-group mb-2"><span class="input-group-text">Ürün Adı</span><input class="form-control" type="text" name="urun_adi" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">İşlem</span><select class="form-select" name="islem" required><option value="giriş">giriş</option><option value="çıkış">çıkış</option><option value="talep">talep</option></select></div>
-          <div class="input-group mb-2"><span class="input-group-text">Adet</span><input class="form-control" type="number" name="adet" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Tarih</span><input class="form-control" type="date" name="tarih"></div>
-          <div class="input-group mb-2"><span class="input-group-text">Lokasyon</span><input class="form-control" type="text" name="lokasyon" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">IFS No</span><input class="form-control" type="text" name="ifs_no" required></div>
-          <div class="input-group mb-2"><span class="input-group-text">Açıklama</span><input class="form-control" type="text" name="aciklama"></div>
-          <div class="input-group mb-2"><span class="input-group-text">İşlem Yapan</span><input class="form-control" type="text" name="islem_yapan" required></div>
-        </div>
+        <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -130,7 +110,7 @@
       <div class="modal-header">
         <h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Silme Onayı</h5>
       </div>
-      <div class="modal-body">Seçili kayıtları silmek istediğinizden emin misiniz?</div>
+        <div class="modal-body"></div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
         <button id="confirm-delete" type="button" class="btn btn-danger">Sil</button>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -42,9 +42,7 @@
         <h5 class="modal-title" id="settingsModalLabel">Kolon Ayarları</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <div class="modal-body">
-        <ul id="columns-list" class="list-group"></ul>
-      </div>
+        <div class="modal-body"></div>
         <div class="modal-footer">
           <button id="save-settings" type="button" class="btn btn-primary">Kaydet</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
@@ -62,44 +60,7 @@
       </div>
       <form id="editForm" action="/printer/add" method="post">
         <input type="hidden" name="printer_id">
-        <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazıcı Markası</span>
-            <select class="form-select" name="yazici_markasi" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazıcı Modeli</span>
-            <input class="form-control" type="text" name="yazici_modeli" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kullanım Alanı</span>
-            <select class="form-select" name="kullanim_alani" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">IP Adresi</span>
-            <input class="form-control" type="text" name="ip_adresi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">MAC</span>
-            <input class="form-control" type="text" name="mac" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Hostname</span>
-            <input class="form-control" type="text" name="hostname" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -116,44 +77,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/printer/add" method="post">
-        <div class="modal-body">
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazıcı Markası</span>
-            <select class="form-select" name="yazici_markasi" required>
-              {% for b in brands %}
-              <option value="{{ b.name }}">{{ b.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Yazıcı Modeli</span>
-            <input class="form-control" type="text" name="yazici_modeli" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Kullanım Alanı</span>
-            <select class="form-select" name="kullanim_alani" required>
-              {% for l in locations %}
-              <option value="{{ l.name }}">{{ l.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">IP Adresi</span>
-            <input class="form-control" type="text" name="ip_adresi" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">MAC</span>
-            <input class="form-control" type="text" name="mac" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Hostname</span>
-            <input class="form-control" type="text" name="hostname" required>
-          </div>
-          <div class="input-group mb-2">
-            <span class="input-group-text">Notlar</span>
-            <input class="form-control" type="text" name="notlar">
-          </div>
-        </div>
+          <div class="modal-body"></div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -185,7 +109,7 @@
       <div class="modal-header">
         <h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Silme Onayı</h5>
       </div>
-      <div class="modal-body">Seçili kayıtları silmek istediğinizden emin misiniz?</div>
+        <div class="modal-body"></div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
         <button id="confirm-delete" type="button" class="btn btn-danger">Sil</button>


### PR DESCRIPTION
## Summary
- Remove all preset modal-body content from inventory, stock, printer and license pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b05307820832bbcd9707aa369a2bf