### PR TITLE
feat: add table management to admin panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,6 +359,37 @@ def cleanup_deleted(db: Session):
 def log_action(db: Session, username: str, action: str):
     db.add(ActivityLog(username=username, action=action))
 
+
+def list_tables():
+    """Return all database tables with row counts."""
+    inspector = inspect(engine)
+    tables = []
+    with engine.connect() as conn:
+        for name in inspector.get_table_names():
+            count = conn.execute(text(f"SELECT COUNT(*) FROM {name}")).scalar()
+            tables.append({"name": name, "count": count})
+    return tables
+
+
+def render_admin_page(
+    request: Request,
+    db: Session,
+    error: str = "",
+    table_error: str = "",
+):
+    """Utility to render admin panel with user and table info."""
+    users = db.query(User).all()
+    return templates.TemplateResponse(
+        "admin.html",
+        {
+            "request": request,
+            "users": users,
+            "tables": list_tables(),
+            "error": error,
+            "table_error": table_error,
+        },
+    )
+
 # --- Pydantic Şemalar ---
 class HardwareItem(BaseModel):
     id: Optional[int]
@@ -587,10 +618,7 @@ def admin_page(
 ):
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="Yetkisiz")
-    users = db.query(User).all()
-    return templates.TemplateResponse(
-        "admin.html", {"request": request, "users": users}
-    )
+    return render_admin_page(request, db)
 
 
 @app.post("/admin/create")
@@ -608,15 +636,7 @@ def admin_create_user(
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="Yetkisiz")
     if db.query(User).filter(User.username == username).first():
-        users = db.query(User).all()
-        return templates.TemplateResponse(
-            "admin.html",
-            {
-                "request": request,
-                "users": users,
-                "error": "Kullanıcı zaten var",
-            },
-        )
+        return render_admin_page(request, db, error="Kullanıcı zaten var")
     db.add(
         User(
             username=username,
@@ -665,6 +685,49 @@ def admin_make_admin(
         raise HTTPException(status_code=404, detail="Kullanıcı bulunamadı")
     target.is_admin = True
     log_action(db, user.username, f"Kullanıcı admin yapıldı: {target.username}")
+    db.commit()
+    return RedirectResponse("/admin", status_code=303)
+
+
+@app.post("/admin/tables/create")
+def admin_create_table(
+    request: Request,
+    table_name: str = Form(...),
+    user: User = Depends(require_login),
+    db: Session = Depends(get_db),
+):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Yetkisiz")
+    if not table_name.isidentifier():
+        return render_admin_page(request, db, table_error="Geçersiz tablo adı")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY)"))
+        log_action(db, user.username, f"Tablo oluşturuldu: {table_name}")
+        db.commit()
+        return RedirectResponse("/admin", status_code=303)
+    except SQLAlchemyError:
+        return render_admin_page(request, db, table_error="Tablo oluşturulamadı")
+
+
+@app.post("/admin/tables/delete")
+def admin_delete_table(
+    request: Request,
+    table_name: str = Form(...),
+    user: User = Depends(require_login),
+    db: Session = Depends(get_db),
+):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Yetkisiz")
+    inspector = inspect(engine)
+    if table_name not in inspector.get_table_names():
+        return render_admin_page(request, db, table_error="Tablo bulunamadı")
+    with engine.connect() as conn:
+        count = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar()
+        if count > 0:
+            return render_admin_page(request, db, table_error="Tablo boş değil")
+        conn.execute(text(f"DROP TABLE {table_name}"))
+    log_action(db, user.username, f"Tablo silindi: {table_name}")
     db.commit()
     return RedirectResponse("/admin", status_code=303)
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -51,4 +51,34 @@
     {% endfor %}
   </tbody>
 </table>
+
+<h2>Tablo Yönetimi</h2>
+{% if table_error %}<div class="alert alert-danger">{{ table_error }}</div>{% endif %}
+<form method="post" action="/admin/tables/create" class="mb-3">
+  <div class="mb-3">
+    <input type="text" name="table_name" class="form-control" placeholder="Tablo Adı" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Tablo Oluştur</button>
+  </form>
+<table class="table">
+  <thead>
+    <tr><th>Tablo Adı</th><th>Kayıt Sayısı</th><th>İşlem</th></tr>
+  </thead>
+  <tbody>
+    {% for t in tables %}
+    <tr>
+      <td>{{ t.name }}</td>
+      <td>{{ t.count }}</td>
+      <td>
+        {% if t.count == 0 %}
+        <form method="post" action="/admin/tables/delete" style="display:inline">
+          <input type="hidden" name="table_name" value="{{ t.name }}">
+          <button type="submit" class="btn btn-danger btn-sm">Sil</button>
+        </form>
+        {% else %}-{% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow administrators to create and delete database tables
- show database tables and row counts on the admin page

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1388ea48832b930bf74487f43335