### PR TITLE
Ensure hardware inventory table is created

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,7 +203,10 @@ def init_db():
         if "email" not in user_cols:
             conn.execute(text("ALTER TABLE users ADD COLUMN email TEXT"))
 
-        # ensure hardware inventory 'no' column exists
+        # ensure hardware inventory table and columns exist
+        if not inspector.has_table("hardware_inventory"):
+            HardwareInventory.__table__.create(bind=engine)
+            inspector = inspect(engine)
         hw_cols = [c["name"] for c in inspector.get_columns("hardware_inventory")]
         if "no" not in hw_cols:
             conn.execute(text("ALTER TABLE hardware_inventory ADD COLUMN no TEXT"))


### PR DESCRIPTION
## Summary
- ensure hardware inventory table is created if missing before column checks

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
import importlib, main
importlib.reload(main)
print('reloaded')
PY`
- `sqlite3 data/envanter.db ".tables"`

------
https://chatgpt.com/codex/tasks/task_e_689b187c1518832babd9229675f71be7