### PR TITLE
Fix trash hardware table to match inventory columns

### DIFF
--- a/templates/trash.html
+++ b/templates/trash.html
@@ -4,24 +4,36 @@
 <h2>Silinen Kayıtlar</h2>
 <div class="alert alert-warning"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Bu kayıtlar 15 gün sonra kalıcı olarak silinecektir.</div>
 
+{% set column_labels = {
+  'no': 'No',
+  'fabrika': 'Fabrika',
+  'blok': 'Blok',
+  'departman': 'Departman',
+  'donanim_tipi': 'Donanım Tipi',
+  'bilgisayar_adi': 'Bilgisayar Adı',
+  'marka': 'Marka',
+  'model': 'Model',
+  'seri_no': 'Seri No',
+  'sorumlu_personel': 'Sorumlu Personel',
+  'kullanim_alani': 'Kullanım Alanı',
+  'bagli_makina_no': 'Bağlı Olduğu Makina No',
+  'notlar': 'Notlar'
+} %}
+
 <h4>Donanım Envanteri</h4>
 <table class="table table-striped table-fixed table-resizable">
   <tr>
-    {% for col in ["demirbas_adi","marka","model","seri_no","lokasyon","zimmetli_kisi","notlar"] %}
-    <th>{{ col.replace('_',' ').title() }}</th>
+    {% for col, label in column_labels.items() %}
+    <th>{{ label }}</th>
     {% endfor %}
     <th>Kalan Gün</th>
     <th>İşlem</th>
   </tr>
   {% for i in hardware %}
   <tr>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.demirbas_adi }}">{{ i.demirbas_adi }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.marka }}">{{ i.marka }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.model }}">{{ i.model }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.seri_no }}">{{ i.seri_no }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.lokasyon }}">{{ i.lokasyon }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.zimmetli_kisi }}">{{ i.zimmetli_kisi }}</td>
-    <td style="white-space: normal; word-break: break-word;" title="{{ i.notlar }}">{{ i.notlar }}</td>
+    {% for col in column_labels.keys() %}
+    <td style="white-space: normal; word-break: break-word;" title="{{ i|attr(col) }}">{{ i|attr(col) }}</td>
+    {% endfor %}
     <td>{{ 15 - (today - i.deleted_at).days }}</td>
     <td>
       <form action="/inventory/restore/{{ i.id }}" method="post" style="display:inline;">


### PR DESCRIPTION
## Summary
- align deleted hardware table with current HardwareInventory schema using dynamic column labels

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b25f21d1c832b850ff0bdd4a1a59b