### PR TITLE
Fix bcrypt import and update Pydantic config

### DIFF
--- a/main.py
+++ b/main.py
@@ -410,7 +410,7 @@ class HardwareItem(BaseModel):
     bagli_makina_no: str
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class PrinterItem(BaseModel):
     id: Optional[int]
@@ -422,7 +422,7 @@ class PrinterItem(BaseModel):
     hostname: str
     notlar: Optional[str]
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class LicenseItem(BaseModel):
     id: Optional[int]
@@ -434,7 +434,7 @@ class LicenseItem(BaseModel):
     zimmetli_kisi: str
     notlar: Optional[str]
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class StockItemSchema(BaseModel):
     id: Optional[int]
@@ -445,7 +445,7 @@ class StockItemSchema(BaseModel):
     lokasyon: str
     guncelleme_tarihi: Optional[date]
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class ColumnDefinition(BaseModel):
     name: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas
 xlrd==2.0.1
 openpyxl
 passlib[bcrypt]
+bcrypt<4.0


### PR DESCRIPTION
## Summary
- Replace deprecated `orm_mode` with `from_attributes` in Pydantic models
- Pin bcrypt to a pre-4.0 version to avoid missing `__about__`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4b2759d4832bb8bff784e92f06d6