### PR TITLE
Add Sentry error tracking and Prometheus metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,23 @@ services:
       - "${HOST_PORT:-5000}:5000"
     environment:
       - DATABASE_URL=sqlite:////app/data/envanter.db
+      - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       - ./data:/app/data
       - ./image:/app/image     # hosttaki image klasörünü container’a bağla
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - envanter
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'envanter'
+    static_configs:
+      - targets: ['envanter:5000']

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ xlrd==2.0.1
 openpyxl
 passlib[bcrypt]
 bcrypt<4.0
+sentry-sdk
+prometheus-fastapi-instrumentator


### PR DESCRIPTION
## Summary
- integrate Sentry for error logging with optional tracing
- expose Prometheus metrics endpoint and add optional Grafana/Prometheus services
- include Prometheus configuration file

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4e0af100832b928d818c8ab6464d