### PR TITLE
Enable pagination and user management improvements

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -38,10 +38,13 @@
       <td>{{ u.email }}</td>
       <td>{{ "Evet" if u.is_admin else "Hayır" }}</td>
       <td>
+        {% if u.username != 'admin' %}
         {% if not u.is_admin %}
         <form method="post" action="/admin/make_admin/{{ u.id }}" style="display:inline">
           <button type="submit" class="btn btn-secondary btn-sm">Admin Yap</button>
         </form>
+        {% endif %}
+        <a href="/admin/edit/{{ u.id }}" class="btn btn-warning btn-sm">Düzenle</a>
         <form method="post" action="/admin/delete/{{ u.id }}" style="display:inline">
           <button type="submit" class="btn btn-danger btn-sm">Sil</button>
         </form>

--- a/templates/admin_edit.html
+++ b/templates/admin_edit.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Kullanıcı Düzenle{% endblock %}
+{% block content %}
+<h2>Kullanıcı Düzenle</h2>
+<form method="post" action="/admin/edit/{{ target.id }}">
+  <div class="mb-3">
+    <label class="form-label">Kullanıcı Adı</label>
+    <input type="text" class="form-control" value="{{ target.username }}" disabled>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Yeni Şifre</label>
+    <input type="password" class="form-control" name="password">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">İsim</label>
+    <input type="text" class="form-control" name="first_name" value="{{ target.first_name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Soyisim</label>
+    <input type="text" class="form-control" name="last_name" value="{{ target.last_name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Mail</label>
+    <input type="email" class="form-control" name="email" value="{{ target.email }}">
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="is_admin" id="is_admin" {% if target.is_admin %}checked{% endif %}>
+    <label class="form-check-label" for="is_admin">Admin</label>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="/admin" class="btn btn-secondary">İptal</a>
+</form>
+{% endblock %}

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -74,7 +74,14 @@
       </div>
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
+              <input type="text" class="form-control" name="{{ col }}" required>
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -90,7 +97,14 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/inventory/add" method="post">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
+              <input type="text" class="form-control" name="{{ col }}" required>
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -115,6 +129,17 @@
     </tr>
     {% endfor %}
 </table>
+
+<nav aria-label="Sayfalar">
+  <ul class="pagination justify-content-center">
+    {% if page > 1 %}
+    <li class="page-item"><a class="page-link" href="/inventory?page={{ page - 1 }}">Önceki</a></li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item"><a class="page-link" href="/inventory?page={{ page + 1 }}">Sonraki</a></li>
+    {% endif %}
+  </ul>
+</nav>
 
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -60,7 +60,18 @@
       </div>
       <form id="editForm" action="/license/add" method="post">
         <input type="hidden" name="license_id">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              {% if col == 'notlar' %}
+              <textarea class="form-control" name="{{ col }}" required></textarea>
+              {% else %}
+              <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -77,7 +88,18 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/license/add" method="post">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              {% if col == 'notlar' %}
+              <textarea class="form-control" name="{{ col }}" required></textarea>
+              {% else %}
+              <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -112,6 +134,17 @@
   </tr>
   {% endfor %}
 </table>
+
+<nav aria-label="Sayfalar">
+  <ul class="pagination justify-content-center">
+    {% if page > 1 %}
+    <li class="page-item"><a class="page-link" href="/license?page={{ page - 1 }}">Önceki</a></li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item"><a class="page-link" href="/license?page={{ page + 1 }}">Sonraki</a></li>
+    {% endif %}
+  </ul>
+</nav>
 
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -59,13 +59,28 @@
         <h5 class="modal-title" id="editModalLabel">Kayıt Düzenle</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-      <form id="editForm" action="/stock/add" method="post">
-        <input type="hidden" name="stock_id">
-          <div class="modal-body"></div>
-        <div class="modal-footer">
-          <button type="submit" class="btn btn-warning">Kaydet</button>
-        </div>
-      </form>
+        <form id="editForm" action="/stock/add" method="post">
+          <input type="hidden" name="stock_id">
+            <div class="modal-body">
+              {% for col in columns %}
+              <div class="mb-3">
+                <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+                {% if col == 'aciklama' %}
+                <textarea class="form-control" name="{{ col }}" required></textarea>
+                {% elif col == 'tarih' %}
+                <input type="date" class="form-control" name="{{ col }}" required>
+                {% elif col == 'adet' %}
+                <input type="number" class="form-control" name="{{ col }}" required>
+                {% else %}
+                <input type="text" class="form-control" name="{{ col }}" required>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-warning">Kaydet</button>
+          </div>
+        </form>
     </div>
   </div>
 </div>
@@ -78,7 +93,22 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/stock/add" method="post">
-        <div class="modal-body"></div>
+        <div class="modal-body">
+          {% for col in columns %}
+          <div class="mb-3">
+            <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+            {% if col == 'aciklama' %}
+            <textarea class="form-control" name="{{ col }}" required></textarea>
+            {% elif col == 'tarih' %}
+            <input type="date" class="form-control" name="{{ col }}" required>
+            {% elif col == 'adet' %}
+            <input type="number" class="form-control" name="{{ col }}" required>
+            {% else %}
+            <input type="text" class="form-control" name="{{ col }}" required>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -103,6 +133,21 @@
     </tr>
     {% endfor %}
 </table>
+
+<nav aria-label="Sayfalar">
+  <ul class="pagination justify-content-center">
+    {% if page > 1 %}
+    <li class="page-item">
+      <a class="page-link" href="/stock?page={{ page - 1 }}">Önceki</a>
+    </li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item">
+      <a class="page-link" href="/stock?page={{ page + 1 }}">Sonraki</a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
 
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -60,7 +60,14 @@
       </div>
       <form id="editForm" action="/printer/add" method="post">
         <input type="hidden" name="printer_id">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              <input type="text" class="form-control" name="{{ col }}" required>
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
         </div>
@@ -77,7 +84,14 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/printer/add" method="post">
-          <div class="modal-body"></div>
+          <div class="modal-body">
+            {% for col in columns %}
+            <div class="mb-3">
+              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              <input type="text" class="form-control" name="{{ col }}" required>
+            </div>
+            {% endfor %}
+          </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
@@ -102,6 +116,17 @@
     </tr>
     {% endfor %}
 </table>
+
+<nav aria-label="Sayfalar">
+  <ul class="pagination justify-content-center">
+    {% if page > 1 %}
+    <li class="page-item"><a class="page-link" href="/printer?page={{ page - 1 }}">Önceki</a></li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item"><a class="page-link" href="/printer?page={{ page + 1 }}">Sonraki</a></li>
+    {% endif %}
+  </ul>
+</nav>
 
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- paginate inventory, license, stock, and printer tables with 50 rows per page
- populate add/edit modals with form fields so records can be created and updated
- allow admins to edit or delete users (except the built-in admin) via new admin edit page

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4ff7df80832bac33b07d62deebe6