### PR TITLE
Add page-size selector and global search to inventory tables

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict
 from datetime import date, timedelta
-from sqlalchemy import create_engine, Column, Integer, String, Date, DateTime, Text, Boolean, text, inspect, func
+from sqlalchemy import create_engine, Column, Integer, String, Date, DateTime, Text, Boolean, text, inspect, func, or_
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
@@ -808,6 +808,8 @@ def add_list_item(
 def inventory_page(
     request: Request,
     page: int = 1,
+    per_page: int = 50,
+    q: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -818,14 +820,17 @@ def inventory_page(
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
     widths = settings.get("widths", {})
-    limit = 50
+    if per_page not in (25, 50, 100):
+        per_page = 50
     page = max(page, 1)
-    offset = (page - 1) * limit
+    offset = (page - 1) * per_page
     query = db.query(HardwareInventory)
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(or_(*(getattr(HardwareInventory, c).ilike(pattern) for c in columns)))
     total = query.count()
-    rows = query.offset(offset).limit(limit + 1).all()
-    has_next = len(rows) > limit
-    items = rows[:limit]
+    items = query.offset(offset).limit(per_page).all()
+    total_pages = (total + per_page - 1) // per_page
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "envanter.html",
@@ -837,7 +842,9 @@ def inventory_page(
             "table_name": table_name,
             "column_widths": widths,
             "page": page,
-            "has_next": has_next,
+            "total_pages": total_pages,
+            "per_page": per_page,
+            "q": q,
         },
     )
 
@@ -1126,6 +1133,8 @@ def export_inventory_excel(
 def license_page(
     request: Request,
     page: int = 1,
+    per_page: int = 50,
+    q: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1136,14 +1145,17 @@ def license_page(
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
     widths = settings.get("widths", {})
-    limit = 50
+    if per_page not in (25, 50, 100):
+        per_page = 50
     page = max(page, 1)
-    offset = (page - 1) * limit
+    offset = (page - 1) * per_page
     query = db.query(LicenseInventory)
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(or_(*(getattr(LicenseInventory, c).ilike(pattern) for c in columns)))
     total = query.count()
-    rows = query.offset(offset).limit(limit + 1).all()
-    has_next = len(rows) > limit
-    licenses = rows[:limit]
+    licenses = query.offset(offset).limit(per_page).all()
+    total_pages = (total + per_page - 1) // per_page
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "lisans.html",
@@ -1155,7 +1167,9 @@ def license_page(
             "table_name": table_name,
             "column_widths": widths,
             "page": page,
-            "has_next": has_next,
+            "total_pages": total_pages,
+            "per_page": per_page,
+            "q": q,
         },
     )
 
@@ -1398,6 +1412,8 @@ def export_license_excel(
 def stock_page(
     request: Request,
     page: int = 1,
+    per_page: int = 50,
+    q: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1408,14 +1424,17 @@ def stock_page(
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
     widths = settings.get("widths", {})
-    limit = 50
+    if per_page not in (25, 50, 100):
+        per_page = 50
     page = max(page, 1)
-    offset = (page - 1) * limit
+    offset = (page - 1) * per_page
     query = db.query(StockItem)
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(or_(*(getattr(StockItem, c).ilike(pattern) for c in columns)))
     total = query.count()
-    rows = query.offset(offset).limit(limit + 1).all()
-    has_next = len(rows) > limit
-    stocks = rows[:limit]
+    stocks = query.offset(offset).limit(per_page).all()
+    total_pages = (total + per_page - 1) // per_page
     display_columns = [c for c in order if c in visible]
     return templates.TemplateResponse(
         "stok.html",
@@ -1427,7 +1446,9 @@ def stock_page(
             "table_name": table_name,
             "column_widths": widths,
             "page": page,
-            "has_next": has_next,
+            "total_pages": total_pages,
+            "per_page": per_page,
+            "q": q,
         },
     )
 
@@ -1682,6 +1703,8 @@ def export_stock_excel(
 def printer_page(
     request: Request,
     page: int = 1,
+    per_page: int = 50,
+    q: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1692,14 +1715,17 @@ def printer_page(
     order = settings.get("order", columns)
     visible = settings.get("visible", columns)
     widths = settings.get("widths", {})
-    limit = 50
+    if per_page not in (25, 50, 100):
+        per_page = 50
     page = max(page, 1)
-    offset = (page - 1) * limit
+    offset = (page - 1) * per_page
     query = db.query(PrinterInventory)
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(or_(*(getattr(PrinterInventory, c).ilike(pattern) for c in columns)))
     total = query.count()
-    rows = query.offset(offset).limit(limit + 1).all()
-    has_next = len(rows) > limit
-    printers = rows[:limit]
+    printers = query.offset(offset).limit(per_page).all()
+    total_pages = (total + per_page - 1) // per_page
     display_columns = [c for c in order if c in visible]
     brands = db.query(LookupItem).filter(LookupItem.type == "marka").all()
     locations = db.query(LookupItem).filter(LookupItem.type == "lokasyon").all()
@@ -1715,7 +1741,9 @@ def printer_page(
             "brands": brands,
             "locations": locations,
             "page": page,
-            "has_next": has_next,
+            "total_pages": total_pages,
+            "per_page": per_page,
+            "q": q,
         },
     )
 

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -42,7 +42,14 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <input id="search-input" type="text" class="form-control ms-auto" placeholder="Ara..." style="max-width: 200px;">
+  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
+    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
+      {% for opt in [25,50,100] %}
+      <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </form>
 </div>
 
 <form id="uploadForm" action="/inventory/upload" method="post" enctype="multipart/form-data" style="display:none;">
@@ -133,10 +140,13 @@
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
     {% if page > 1 %}
-    <li class="page-item"><a class="page-link" href="/inventory?page={{ page - 1 }}">Önceki</a></li>
+    <li class="page-item"><a class="page-link" href="/inventory?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% if has_next %}
-    <li class="page-item"><a class="page-link" href="/inventory?page={{ page + 1 }}">Sonraki</a></li>
+    {% for p in range(1, total_pages + 1) %}
+    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/inventory?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
+    {% endfor %}
+    {% if page < total_pages %}
+    <li class="page-item"><a class="page-link" href="/inventory?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
     {% endif %}
   </ul>
 </nav>
@@ -292,5 +302,11 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
     deleteModal.hide();
     location.reload();
 });
+const perPageSelect = document.getElementById('per-page');
+if (perPageSelect) {
+    perPageSelect.addEventListener('change', () => {
+        document.getElementById('search-form').submit();
+    });
+}
 </script>
 {% endblock %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -28,7 +28,14 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <input id="search-input" type="text" class="form-control ms-auto" placeholder="Ara..." style="max-width: 200px;">
+  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
+    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
+      {% for opt in [25,50,100] %}
+      <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </form>
 </div>
 
 <form id="uploadForm" action="/license/upload" method="post" enctype="multipart/form-data" style="display:none;">
@@ -138,10 +145,13 @@
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
     {% if page > 1 %}
-    <li class="page-item"><a class="page-link" href="/license?page={{ page - 1 }}">Önceki</a></li>
+    <li class="page-item"><a class="page-link" href="/license?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% if has_next %}
-    <li class="page-item"><a class="page-link" href="/license?page={{ page + 1 }}">Sonraki</a></li>
+    {% for p in range(1, total_pages + 1) %}
+    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/license?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
+    {% endfor %}
+    {% if page < total_pages %}
+    <li class="page-item"><a class="page-link" href="/license?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
     {% endif %}
   </ul>
 </nav>
@@ -296,5 +306,11 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
     deleteModal.hide();
     location.reload();
 });
+const perPageSelect = document.getElementById('per-page');
+if (perPageSelect) {
+    perPageSelect.addEventListener('change', () => {
+        document.getElementById('search-form').submit();
+    });
+}
 </script>
 {% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -29,7 +29,14 @@
     <i class="bi bi-trash"></i>
   </button>
   <a class="btn btn-info" href="/stock/status" style="height:40px;display:flex;align-items:center;">Stok Durumu</a>
-  <input id="search-input" type="text" class="form-control ms-auto" placeholder="Ara..." style="max-width: 200px;">
+  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
+    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
+      {% for opt in [25,50,100] %}
+      <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </form>
 </div>
 
 <form id="uploadForm" action="/stock/upload" method="post" enctype="multipart/form-data" style="display:none;">
@@ -137,14 +144,13 @@
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
     {% if page > 1 %}
-    <li class="page-item">
-      <a class="page-link" href="/stock?page={{ page - 1 }}">Önceki</a>
-    </li>
+    <li class="page-item"><a class="page-link" href="/stock?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% if has_next %}
-    <li class="page-item">
-      <a class="page-link" href="/stock?page={{ page + 1 }}">Sonraki</a>
-    </li>
+    {% for p in range(1, total_pages + 1) %}
+    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/stock?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
+    {% endfor %}
+    {% if page < total_pages %}
+    <li class="page-item"><a class="page-link" href="/stock?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
     {% endif %}
   </ul>
 </nav>
@@ -299,5 +305,11 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
     deleteModal.hide();
     location.reload();
 });
+const perPageSelect = document.getElementById('per-page');
+if (perPageSelect) {
+    perPageSelect.addEventListener('change', () => {
+        document.getElementById('search-form').submit();
+    });
+}
 </script>
 {% endblock %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -28,7 +28,14 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <input id="search-input" type="text" class="form-control ms-auto" placeholder="Ara..." style="max-width: 200px;">
+  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
+    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
+      {% for opt in [25,50,100] %}
+      <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </form>
 </div>
 
 <form id="uploadForm" action="/printer/upload" method="post" enctype="multipart/form-data" style="display:none;">
@@ -120,10 +127,13 @@
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
     {% if page > 1 %}
-    <li class="page-item"><a class="page-link" href="/printer?page={{ page - 1 }}">Önceki</a></li>
+    <li class="page-item"><a class="page-link" href="/printer?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% if has_next %}
-    <li class="page-item"><a class="page-link" href="/printer?page={{ page + 1 }}">Sonraki</a></li>
+    {% for p in range(1, total_pages + 1) %}
+    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/printer?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
+    {% endfor %}
+    {% if page < total_pages %}
+    <li class="page-item"><a class="page-link" href="/printer?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
     {% endif %}
   </ul>
 </nav>
@@ -278,5 +288,11 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
     deleteModal.hide();
     location.reload();
 });
+const perPageSelect = document.getElementById('per-page');
+if (perPageSelect) {
+    perPageSelect.addEventListener('change', () => {
+        document.getElementById('search-form').submit();
+    });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow inventory, license, stock and printer pages to search across all columns
- Let users choose 25, 50 or 100 rows per page with numbered pagination
- Auto-submit when page size changes

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2e7d3bbc832b9cb47a2c99fd0294