### PR TITLE
Improve pagination and default stock view

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -139,14 +139,17 @@
 
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
+    {% set start = ((page - 1) // 10) * 10 + 1 %}
+    {% set end = start + 9 if start + 9 < total_pages else total_pages %}
     {% if page > 1 %}
     <li class="page-item"><a class="page-link" href="/inventory?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% for p in range(1, total_pages + 1) %}
+    {% for p in range(start, end + 1) %}
     <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/inventory?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
     {% endfor %}
     {% if page < total_pages %}
     <li class="page-item"><a class="page-link" href="/inventory?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
+    <li class="page-item"><a class="page-link" href="/inventory?page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -144,14 +144,17 @@
 
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
+    {% set start = ((page - 1) // 10) * 10 + 1 %}
+    {% set end = start + 9 if start + 9 < total_pages else total_pages %}
     {% if page > 1 %}
     <li class="page-item"><a class="page-link" href="/license?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% for p in range(1, total_pages + 1) %}
+    {% for p in range(start, end + 1) %}
     <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/license?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
     {% endfor %}
     {% if page < total_pages %}
     <li class="page-item"><a class="page-link" href="/license?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
+    <li class="page-item"><a class="page-link" href="/license?page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -143,14 +143,17 @@
 
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
+    {% set start = ((page - 1) // 10) * 10 + 1 %}
+    {% set end = start + 9 if start + 9 < total_pages else total_pages %}
     {% if page > 1 %}
     <li class="page-item"><a class="page-link" href="/stock?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% for p in range(1, total_pages + 1) %}
+    {% for p in range(start, end + 1) %}
     <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/stock?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
     {% endfor %}
     {% if page < total_pages %}
     <li class="page-item"><a class="page-link" href="/stock?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
+    <li class="page-item"><a class="page-link" href="/stock?page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -126,14 +126,17 @@
 
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">
+    {% set start = ((page - 1) // 10) * 10 + 1 %}
+    {% set end = start + 9 if start + 9 < total_pages else total_pages %}
     {% if page > 1 %}
     <li class="page-item"><a class="page-link" href="/printer?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
-    {% for p in range(1, total_pages + 1) %}
+    {% for p in range(start, end + 1) %}
     <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/printer?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
     {% endfor %}
     {% if page < total_pages %}
     <li class="page-item"><a class="page-link" href="/printer?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
+    <li class="page-item"><a class="page-link" href="/printer?page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
     {% endif %}
   </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Show only 10 page numbers at a time and add a quick link to the last page across inventory, license, stock and printer listings
- Open stock tracking on the final page by default

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c3221905c832b81a66ade368a5883