### PR TITLE
Enable automatic numbering for tracking lists

### DIFF
--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -10,11 +10,11 @@
       <input class="form-control" type="text" name="name" placeholder="Yeni marka" required>
       <button class="btn btn-success" type="submit">Ekle</button>
     </form>
-    <ul class="list-group">
+    <ol class="list-group list-group-numbered">
       {% for b in brands %}
       <li class="list-group-item">{{ b.name }}</li>
       {% endfor %}
-    </ul>
+    </ol>
   </div>
   <div class="col-md-3">
     <h5>Lokasyon</h5>
@@ -23,11 +23,11 @@
       <input class="form-control" type="text" name="name" placeholder="Yeni lokasyon" required>
       <button class="btn btn-success" type="submit">Ekle</button>
     </form>
-    <ul class="list-group">
+    <ol class="list-group list-group-numbered">
       {% for l in locations %}
       <li class="list-group-item">{{ l.name }}</li>
       {% endfor %}
-    </ul>
+    </ol>
   </div>
   <div class="col-md-3">
     <h5>Kategori</h5>
@@ -36,11 +36,11 @@
       <input class="form-control" type="text" name="name" placeholder="Yeni kategori" required>
       <button class="btn btn-success" type="submit">Ekle</button>
     </form>
-    <ul class="list-group">
+    <ol class="list-group list-group-numbered">
       {% for c in categories %}
       <li class="list-group-item">{{ c.name }}</li>
       {% endfor %}
-    </ul>
+    </ol>
   </div>
   <div class="col-md-3">
     <h5>Yazılım</h5>
@@ -49,11 +49,11 @@
       <input class="form-control" type="text" name="name" placeholder="Yeni yazılım" required>
       <button class="btn btn-success" type="submit">Ekle</button>
     </form>
-    <ul class="list-group">
+    <ol class="list-group list-group-numbered">
       {% for s in softwares %}
       <li class="list-group-item">{{ s.name }}</li>
       {% endfor %}
-    </ul>
+    </ol>
   </div>
 </div>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -7,14 +7,14 @@
   <div class="col-md-4 mb-3">
     <div class="card">
       <div class="card-header">{{ factory }}</div>
-      <ul class="list-group list-group-flush">
+      <ol class="list-group list-group-flush list-group-numbered">
         {% for cat in categories %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
           {{ cat.kategori }}
           <span class="badge bg-primary rounded-pill">{{ cat.adet }}</span>
         </li>
         {% endfor %}
-      </ul>
+      </ol>
     </div>
   </div>
   {% endfor %}
@@ -23,13 +23,13 @@
 <div class="mt-4">
   <h2>Son İşlemler</h2>
   <div class="card">
-    <ul class="list-group list-group-flush">
+    <ol class="list-group list-group-flush list-group-numbered">
       {% for log in actions %}
       <li class="list-group-item">
         {{ log.timestamp }} - {{ log.username }} = {{ log.action }}
       </li>
       {% endfor %}
-    </ul>
+    </ol>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Use Bootstrap's `list-group-numbered` on inventory list management page so items show their index
- Display numbered lists on the main dashboard for categories and recent actions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c35ca5148832b8c4a900b9f8d57cd