### PR TITLE
Enable server-side search with pagination

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -110,21 +110,19 @@
     }
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('table.table-resizable').forEach(makeTableResizable);
+      const searchForm = document.getElementById('search-form');
       const searchInput = document.getElementById('search-input');
-      if (searchInput) {
+      if (searchForm && searchInput) {
+        let searchTimeout;
         searchInput.addEventListener('input', () => {
-          const filter = searchInput.value.toLowerCase();
-          document.querySelectorAll('table.table-striped tr').forEach((row, index) => {
-            if (index === 0) return;
-            const text = row.innerText.toLowerCase();
-            row.style.display = text.includes(filter) ? '' : 'none';
-          });
+          clearTimeout(searchTimeout);
+          searchTimeout = setTimeout(() => searchForm.submit(), 500);
         });
       }
       const perPage = document.getElementById('per-page');
-      if (perPage) {
+      if (perPage && searchForm) {
         perPage.addEventListener('change', () => {
-          document.getElementById('search-form').submit();
+          searchForm.submit();
         });
       }
     });


### PR DESCRIPTION
## Summary
- Submit search queries to the backend so filtering covers all records
- Keep per-page selector submitting the same form

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c377d773c832bb4adb4cd78a51792