### PR TITLE
Add row numbers and lookup suggestions

### DIFF
--- a/main.py
+++ b/main.py
@@ -779,6 +779,13 @@ def lists_page(
     locations = db.query(LookupItem).filter(LookupItem.type == "lokasyon").all()
     categories = db.query(LookupItem).filter(LookupItem.type == "kategori").all()
     softwares = db.query(LookupItem).filter(LookupItem.type == "yazilim").all()
+    factories = db.query(LookupItem).filter(LookupItem.type == "fabrika").all()
+    departments = db.query(LookupItem).filter(LookupItem.type == "departman").all()
+    blocks = db.query(LookupItem).filter(LookupItem.type == "blok").all()
+    models = db.query(LookupItem).filter(LookupItem.type == "model").all()
+    printer_brands = db.query(LookupItem).filter(LookupItem.type == "yazici_marka").all()
+    printer_models = db.query(LookupItem).filter(LookupItem.type == "yazici_model").all()
+    products = db.query(LookupItem).filter(LookupItem.type == "urun").all()
     return templates.TemplateResponse(
         "listeler.html",
         {
@@ -787,6 +794,13 @@ def lists_page(
             "locations": locations,
             "categories": categories,
             "softwares": softwares,
+            "factories": factories,
+            "departments": departments,
+            "blocks": blocks,
+            "models": models,
+            "printer_brands": printer_brands,
+            "printer_models": printer_models,
+            "products": products,
         },
     )
 
@@ -834,6 +848,18 @@ def inventory_page(
     offset = (page - 1) * per_page
     items = query.offset(offset).limit(per_page).all()
     display_columns = [c for c in order if c in visible]
+    lookup_map = {
+        "fabrika": "fabrika",
+        "departman": "departman",
+        "blok": "blok",
+        "marka": "marka",
+        "model": "model",
+        "kullanim_alani": "lokasyon",
+    }
+    lookups = {
+        col: [li.name for li in db.query(LookupItem).filter(LookupItem.type == ltype).all()]
+        for col, ltype in lookup_map.items()
+    }
     return templates.TemplateResponse(
         "envanter.html",
         {
@@ -847,6 +873,8 @@ def inventory_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "offset": offset,
+            "lookups": lookups,
         },
     )
 
@@ -1161,6 +1189,14 @@ def license_page(
     offset = (page - 1) * per_page
     licenses = query.offset(offset).limit(per_page).all()
     display_columns = [c for c in order if c in visible]
+    lookup_map = {
+        "departman": "departman",
+        "yazilim_adi": "yazilim",
+    }
+    lookups = {
+        col: [li.name for li in db.query(LookupItem).filter(LookupItem.type == ltype).all()]
+        for col, ltype in lookup_map.items()
+    }
     return templates.TemplateResponse(
         "lisans.html",
         {
@@ -1174,6 +1210,8 @@ def license_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "offset": offset,
+            "lookups": lookups,
         },
     )
 
@@ -1443,6 +1481,16 @@ def stock_page(
     offset = (page - 1) * per_page
     stocks = query.offset(offset).limit(per_page).all()
     display_columns = [c for c in order if c in visible]
+    lookup_map = {
+        "urun_adi": "urun",
+        "kategori": "kategori",
+        "marka": "marka",
+        "lokasyon": "lokasyon",
+    }
+    lookups = {
+        col: [li.name for li in db.query(LookupItem).filter(LookupItem.type == ltype).all()]
+        for col, ltype in lookup_map.items()
+    }
     return templates.TemplateResponse(
         "stok.html",
         {
@@ -1456,6 +1504,8 @@ def stock_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "offset": offset,
+            "lookups": lookups,
         },
     )
 
@@ -1736,8 +1786,15 @@ def printer_page(
     offset = (page - 1) * per_page
     printers = query.offset(offset).limit(per_page).all()
     display_columns = [c for c in order if c in visible]
-    brands = db.query(LookupItem).filter(LookupItem.type == "marka").all()
-    locations = db.query(LookupItem).filter(LookupItem.type == "lokasyon").all()
+    lookup_map = {
+        "yazici_markasi": "yazici_marka",
+        "yazici_modeli": "yazici_model",
+        "kullanim_alani": "lokasyon",
+    }
+    lookups = {
+        col: [li.name for li in db.query(LookupItem).filter(LookupItem.type == ltype).all()]
+        for col, ltype in lookup_map.items()
+    }
     return templates.TemplateResponse(
         "yazici.html",
         {
@@ -1747,12 +1804,14 @@ def printer_page(
             "columns": display_columns,
             "table_name": table_name,
             "column_widths": widths,
-            "brands": brands,
-            "locations": locations,
+            "brands": db.query(LookupItem).filter(LookupItem.type == "marka").all(),
+            "locations": db.query(LookupItem).filter(LookupItem.type == "lokasyon").all(),
             "page": page,
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "offset": offset,
+            "lookups": lookups,
         },
     )
 

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -85,7 +85,16 @@
             {% for col in columns %}
             <div class="mb-3">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
             </div>
             {% endfor %}
           </div>
@@ -108,7 +117,16 @@
             {% for col in columns %}
             <div class="mb-3">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
             </div>
             {% endfor %}
           </div>
@@ -123,6 +141,7 @@
 <table class="table table-striped table-fixed table-resizable">
     <tr>
         <th><input type="checkbox" id="select-all"></th>
+        <th>#</th>
         {% for col in columns %}
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ column_labels.get(col, col.replace('_', ' ').title()) }}</th>
         {% endfor %}
@@ -130,6 +149,7 @@
     {% for i in items %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ i.id }}"></td>
+        <td>{{ loop.index + offset }}</td>
         {% for col in columns %}
         <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ i|attr(col) }}</td>
         {% endfor %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -74,7 +74,16 @@
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% else %}
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
               {% endif %}
             </div>
             {% endfor %}
@@ -102,7 +111,16 @@
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% else %}
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
               {% endif %}
             </div>
             {% endfor %}
@@ -128,6 +146,7 @@
 
   <tr>
       <th><input type="checkbox" id="select-all"></th>
+      <th>#</th>
       {% for col in columns %}
       <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ column_labels.get(col, col.replace('_', ' ').title()) }}</th>
       {% endfor %}
@@ -135,6 +154,7 @@
   {% for l in licenses %}
   <tr>
       <td><input class="form-check-input row-check" type="checkbox" value="{{ l.id }}"></td>
+      <td>{{ loop.index + offset }}</td>
       {% for col in columns %}
       <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ l|attr(col) }}</td>
       {% endfor %}

--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -56,4 +56,101 @@
     </ol>
   </div>
 </div>
+
+<div class="row mt-4">
+  <div class="col-md-3">
+    <h5>Fabrika</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="fabrika">
+      <input class="form-control" type="text" name="name" placeholder="Yeni fabrika" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for f in factories %}
+      <li class="list-group-item">{{ f.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <div class="col-md-3">
+    <h5>Departman</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="departman">
+      <input class="form-control" type="text" name="name" placeholder="Yeni departman" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for d in departments %}
+      <li class="list-group-item">{{ d.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <div class="col-md-3">
+    <h5>Blok</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="blok">
+      <input class="form-control" type="text" name="name" placeholder="Yeni blok" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for b in blocks %}
+      <li class="list-group-item">{{ b.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <div class="col-md-3">
+    <h5>Model</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="model">
+      <input class="form-control" type="text" name="name" placeholder="Yeni model" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for m in models %}
+      <li class="list-group-item">{{ m.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+</div>
+
+<div class="row mt-4">
+  <div class="col-md-4">
+    <h5>Yazıcı Markası</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="yazici_marka">
+      <input class="form-control" type="text" name="name" placeholder="Yeni yazıcı markası" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for pb in printer_brands %}
+      <li class="list-group-item">{{ pb.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <div class="col-md-4">
+    <h5>Yazıcı Modeli</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="yazici_model">
+      <input class="form-control" type="text" name="name" placeholder="Yeni yazıcı modeli" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for pm in printer_models %}
+      <li class="list-group-item">{{ pm.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <div class="col-md-4">
+    <h5>Ürün Adı</h5>
+    <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+      <input type="hidden" name="item_type" value="urun">
+      <input class="form-control" type="text" name="name" placeholder="Yeni ürün adı" required>
+      <button class="btn btn-success" type="submit">Ekle</button>
+    </form>
+    <ol class="list-group list-group-numbered">
+      {% for pr in products %}
+      <li class="list-group-item">{{ pr.name }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+</div>
 {% endblock %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -79,7 +79,16 @@
                 {% elif col == 'adet' %}
                 <input type="number" class="form-control" name="{{ col }}" required>
                 {% else %}
+                {% if lookups.get(col) %}
+                <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+                <datalist id="{{ col }}-list">
+                  {% for val in lookups.get(col) %}
+                  <option value="{{ val }}">
+                  {% endfor %}
+                </datalist>
+                {% else %}
                 <input type="text" class="form-control" name="{{ col }}" required>
+                {% endif %}
                 {% endif %}
               </div>
               {% endfor %}
@@ -111,7 +120,16 @@
             {% elif col == 'adet' %}
             <input type="number" class="form-control" name="{{ col }}" required>
             {% else %}
+            {% if lookups.get(col) %}
+            <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+            <datalist id="{{ col }}-list">
+              {% for val in lookups.get(col) %}
+              <option value="{{ val }}">
+              {% endfor %}
+            </datalist>
+            {% else %}
             <input type="text" class="form-control" name="{{ col }}" required>
+            {% endif %}
             {% endif %}
           </div>
           {% endfor %}
@@ -127,6 +145,7 @@
 <table class="table table-striped table-fixed table-resizable">
     <tr>
         <th><input type="checkbox" id="select-all"></th>
+        <th>#</th>
         {% for col in columns %}
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
@@ -134,6 +153,7 @@
     {% for s in stocks %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ s.id }}"></td>
+        <td>{{ loop.index + offset }}</td>
         {% for col in columns %}
         <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ s|attr(col) }}</td>
         {% endfor %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -71,7 +71,16 @@
             {% for col in columns %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
             </div>
             {% endfor %}
           </div>
@@ -95,7 +104,16 @@
             {% for col in columns %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+              {% if lookups.get(col) %}
+              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
+              <datalist id="{{ col }}-list">
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">
+                {% endfor %}
+              </datalist>
+              {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
             </div>
             {% endfor %}
           </div>
@@ -110,6 +128,7 @@
 <table class="table table-striped table-fixed table-resizable">
     <tr>
         <th><input type="checkbox" id="select-all"></th>
+        <th>#</th>
         {% for col in columns %}
         <th{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px;"{% endif %}>{{ col.replace('_', ' ').title() }}</th>
         {% endfor %}
@@ -117,6 +136,7 @@
     {% for p in printers %}
     <tr>
         <td><input class="form-check-input row-check" type="checkbox" value="{{ p.id }}"></td>
+        <td>{{ loop.index + offset }}</td>
         {% for col in columns %}
         <td data-col="{{ col }}"{% if column_widths.get(col) %} style="width: {{ column_widths[col] }}px; white-space: normal; word-break: break-word;"{% else %} style="white-space: normal; word-break: break-word;"{% endif %}>{{ p|attr(col) }}</td>
         {% endfor %}


### PR DESCRIPTION
## Summary
- Show sequential, non-editable row numbers on inventory, license, printer and stock tables
- Add lookup-based dropdown suggestions when adding or editing records
- Extend list management to handle factories, departments, blocks, models, printer brands/models and product names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c3941f8c0832b8e877a891944660e