### PR TITLE
Limit manual inventory inputs and add hardware dashboard chart

### DIFF
--- a/main.py
+++ b/main.py
@@ -597,18 +597,29 @@ def home_page(
 
     factory_rows = (
         db.query(
-            StockItem.lokasyon,
-            StockItem.kategori,
-            func.sum(StockItem.adet).label("adet"),
+            HardwareInventory.fabrika,
+            HardwareInventory.donanim_tipi,
+            func.count(HardwareInventory.id).label("adet"),
         )
-        .group_by(StockItem.lokasyon, StockItem.kategori)
+        .group_by(HardwareInventory.fabrika, HardwareInventory.donanim_tipi)
         .all()
     )
     factories: Dict[str, List[Dict[str, int]]] = {}
-    for lokasyon, kategori, adet in factory_rows:
-        factories.setdefault(lokasyon or "Bilinmiyor", []).append(
-            {"kategori": kategori, "adet": adet}
+    for fabrika, donanim_tipi, adet in factory_rows:
+        factories.setdefault(fabrika or "Bilinmiyor", []).append(
+            {"kategori": donanim_tipi, "adet": adet}
         )
+
+    type_rows = (
+        db.query(
+            HardwareInventory.donanim_tipi,
+            func.count(HardwareInventory.id).label("adet"),
+        )
+        .group_by(HardwareInventory.donanim_tipi)
+        .all()
+    )
+    type_labels = [t or "Bilinmiyor" for t, _ in type_rows]
+    type_counts = [c for _, c in type_rows]
 
     actions = (
         db.query(ActivityLog)
@@ -623,6 +634,8 @@ def home_page(
             "username": username,
             "factories": factories,
             "actions": actions,
+            "type_labels": type_labels,
+            "type_counts": type_counts,
         },
     )
 

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -86,12 +86,12 @@
             <div class="mb-3">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -118,12 +118,12 @@
             <div class="mb-3">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -75,12 +75,12 @@
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% else %}
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -112,12 +112,12 @@
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% else %}
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -21,6 +21,11 @@
 </div>
 
 <div class="mt-4">
+  <h2>Donanım Dağılımı</h2>
+  <canvas id="hardwareChart"></canvas>
+</div>
+
+<div class="mt-4">
   <h2>Son İşlemler</h2>
   <div class="card">
     <ol class="list-group list-group-flush list-group-numbered">
@@ -32,5 +37,24 @@
     </ol>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const ctx = document.getElementById('hardwareChart');
+new Chart(ctx, {
+  type: 'pie',
+  data: {
+    labels: {{ type_labels | tojson }},
+    datasets: [{
+      data: {{ type_counts | tojson }},
+      backgroundColor: [
+        '#ff6384', '#36a2eb', '#ffce56', '#4bc0c0', '#9966ff', '#ff9f40'
+      ],
+    }]
+  }
+});
+</script>
 {% endblock %}
 

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -80,12 +80,12 @@
                 <input type="number" class="form-control" name="{{ col }}" required>
                 {% else %}
                 {% if lookups.get(col) %}
-                <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-                <datalist id="{{ col }}-list">
+                <select class="form-select" name="{{ col }}" required>
+                  <option value="" disabled selected>Seçiniz</option>
                   {% for val in lookups.get(col) %}
-                  <option value="{{ val }}">
+                  <option value="{{ val }}">{{ val }}</option>
                   {% endfor %}
-                </datalist>
+                </select>
                 {% else %}
                 <input type="text" class="form-control" name="{{ col }}" required>
                 {% endif %}
@@ -121,12 +121,12 @@
             <input type="number" class="form-control" name="{{ col }}" required>
             {% else %}
             {% if lookups.get(col) %}
-            <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-            <datalist id="{{ col }}-list">
+            <select class="form-select" name="{{ col }}" required>
+              <option value="" disabled selected>Seçiniz</option>
               {% for val in lookups.get(col) %}
-              <option value="{{ val }}">
+              <option value="{{ val }}">{{ val }}</option>
               {% endfor %}
-            </datalist>
+            </select>
             {% else %}
             <input type="text" class="form-control" name="{{ col }}" required>
             {% endif %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -72,12 +72,12 @@
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -105,12 +105,12 @@
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if lookups.get(col) %}
-              <input type="text" class="form-control" name="{{ col }}" list="{{ col }}-list" required>
-              <datalist id="{{ col }}-list">
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
-                <option value="{{ val }}">
+                <option value="{{ val }}">{{ val }}</option>
                 {% endfor %}
-              </datalist>
+              </select>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}


### PR DESCRIPTION
## Summary
- restrict inventory, stock, license and printer forms to predefined lookup lists
- show pie chart of hardware type distribution on home page
- compute hardware counts per factory for dashboard display

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c46b37894832ba2fb0fc46f1827f3