### PR TITLE
Arrange list entries and add bulk trash deletion

### DIFF
--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -2,8 +2,8 @@
 {% block title %}Envanter Ekleme{% endblock %}
 {% block content %}
 <h2>Envanter Ekleme</h2>
-<div class="row">
-  <div class="col-md-3">
+<div class="row row-cols-1 row-cols-md-3 g-4">
+  <div class="col">
     <h5>Marka</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="marka">
@@ -16,7 +16,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Lokasyon</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="lokasyon">
@@ -29,7 +29,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Kategori</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="kategori">
@@ -42,7 +42,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Yazılım</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="yazilim">
@@ -55,10 +55,7 @@
       {% endfor %}
     </ol>
   </div>
-</div>
-
-<div class="row mt-4">
-  <div class="col-md-3">
+  <div class="col">
     <h5>Fabrika</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="fabrika">
@@ -71,7 +68,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Departman</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="departman">
@@ -84,7 +81,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Blok</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="blok">
@@ -97,7 +94,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-3">
+  <div class="col">
     <h5>Model</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="model">
@@ -110,10 +107,7 @@
       {% endfor %}
     </ol>
   </div>
-</div>
-
-<div class="row mt-4">
-  <div class="col-md-4">
+  <div class="col">
     <h5>Yazıcı Markası</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="yazici_marka">
@@ -126,7 +120,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-4">
+  <div class="col">
     <h5>Yazıcı Modeli</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="yazici_model">
@@ -139,7 +133,7 @@
       {% endfor %}
     </ol>
   </div>
-  <div class="col-md-4">
+  <div class="col">
     <h5>Ürün Adı</h5>
     <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
       <input type="hidden" name="item_type" value="urun">

--- a/templates/trash.html
+++ b/templates/trash.html
@@ -21,8 +21,13 @@
 } %}
 
 <h4>Donanım Envanteri</h4>
+<form id="delete-hardware-form" action="/trash/delete" method="post" class="mb-2">
+  <input type="hidden" name="item_type" value="hardware">
+  <button type="submit" class="btn btn-danger btn-sm">Seçilenleri Kalıcı Sil</button>
+</form>
 <table class="table table-striped table-fixed table-resizable">
   <tr>
+    <th><input type="checkbox" class="form-check-input select-all"></th>
     {% for col, label in column_labels.items() %}
     <th>{{ label }}</th>
     {% endfor %}
@@ -31,6 +36,7 @@
   </tr>
   {% for i in hardware %}
   <tr>
+    <td><input class="form-check-input row-check" type="checkbox" name="ids" value="{{ i.id }}" form="delete-hardware-form"></td>
     {% for col in column_labels.keys() %}
     <td style="white-space: normal; word-break: break-word;" title="{{ i|attr(col) }}">{{ i|attr(col) }}</td>
     {% endfor %}
@@ -45,8 +51,13 @@
 </table>
 
 <h4>Lisans Envanteri</h4>
+<form id="delete-license-form" action="/trash/delete" method="post" class="mb-2">
+  <input type="hidden" name="item_type" value="license">
+  <button type="submit" class="btn btn-danger btn-sm">Seçilenleri Kalıcı Sil</button>
+</form>
 <table class="table table-striped table-fixed table-resizable">
   <tr>
+    <th><input type="checkbox" class="form-check-input select-all"></th>
     {% for col in ["yazilim_adi","lisans_anahtari","adet","satin_alma_tarihi","bitis_tarihi","zimmetli_kisi","notlar"] %}
     <th>{{ col.replace('_',' ').title() }}</th>
     {% endfor %}
@@ -55,6 +66,7 @@
   </tr>
   {% for l in licenses %}
   <tr>
+    <td><input class="form-check-input row-check" type="checkbox" name="ids" value="{{ l.id }}" form="delete-license-form"></td>
     <td style="white-space: normal; word-break: break-word;" title="{{ l.yazilim_adi }}">{{ l.yazilim_adi }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ l.lisans_anahtari }}">{{ l.lisans_anahtari }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ l.adet }}">{{ l.adet }}</td>
@@ -73,8 +85,13 @@
 </table>
 
 <h4>Yazıcı Envanteri</h4>
+<form id="delete-printer-form" action="/trash/delete" method="post" class="mb-2">
+  <input type="hidden" name="item_type" value="printer">
+  <button type="submit" class="btn btn-danger btn-sm">Seçilenleri Kalıcı Sil</button>
+</form>
 <table class="table table-striped table-fixed table-resizable">
   <tr>
+    <th><input type="checkbox" class="form-check-input select-all"></th>
     {% for col in ["yazici_markasi","yazici_modeli","kullanim_alani","ip_adresi","mac","hostname","notlar"] %}
     <th>{{ col.replace('_',' ').title() }}</th>
     {% endfor %}
@@ -83,6 +100,7 @@
   </tr>
   {% for p in printers %}
   <tr>
+    <td><input class="form-check-input row-check" type="checkbox" name="ids" value="{{ p.id }}" form="delete-printer-form"></td>
     <td style="white-space: normal; word-break: break-word;" title="{{ p.yazici_markasi }}">{{ p.yazici_markasi }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ p.yazici_modeli }}">{{ p.yazici_modeli }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ p.kullanim_alani }}">{{ p.kullanim_alani }}</td>
@@ -101,8 +119,13 @@
 </table>
 
 <h4>Stok Takibi</h4>
+<form id="delete-stock-form" action="/trash/delete" method="post" class="mb-2">
+  <input type="hidden" name="item_type" value="stock">
+  <button type="submit" class="btn btn-danger btn-sm">Seçilenleri Kalıcı Sil</button>
+</form>
 <table class="table table-striped table-fixed table-resizable">
   <tr>
+    <th><input type="checkbox" class="form-check-input select-all"></th>
     {% for col in ["urun_adi","kategori","marka","adet","lokasyon","guncelleme_tarihi"] %}
     <th>{{ col.replace('_',' ').title() }}</th>
     {% endfor %}
@@ -111,6 +134,7 @@
   </tr>
   {% for s in stocks %}
   <tr>
+    <td><input class="form-check-input row-check" type="checkbox" name="ids" value="{{ s.id }}" form="delete-stock-form"></td>
     <td style="white-space: normal; word-break: break-word;" title="{{ s.urun_adi }}">{{ s.urun_adi }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ s.kategori }}">{{ s.kategori }}</td>
     <td style="white-space: normal; word-break: break-word;" title="{{ s.marka }}">{{ s.marka }}</td>
@@ -127,5 +151,16 @@
   {% endfor %}
 </table>
 
+{% endblock %}
+
+{% block scripts %}
+<script>
+  document.querySelectorAll('.select-all').forEach(cb => {
+    cb.addEventListener('change', function () {
+      const table = this.closest('table');
+      table.querySelectorAll('.row-check').forEach(rb => rb.checked = this.checked);
+    });
+  });
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Display all addable inventory lists in a 3-column grid for easier navigation
- Enable permanent deletion of selected trash items with bulk select

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4ced093c832b863522b756bf26c8