### PR TITLE
Add accessory tracking page and request deletion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1888,6 +1888,14 @@ def request_tracking_page(
     )
 
 
+@app.get("/accessories", response_class=HTMLResponse)
+def accessories_page(
+    request: Request,
+    user: User = Depends(require_login),
+):
+    return templates.TemplateResponse("aksesuar.html", {"request": request})
+
+
 @app.post("/requests/add")
 def add_request_form(
     urun_adi: List[str] = Form(...),
@@ -1946,6 +1954,20 @@ def transfer_requests(
     log_action(db, user.username, f"{len(items)} talep stok kayıtlarına aktarıldı")
     db.commit()
     return {"message": "ok"}
+
+
+@app.post("/requests/delete")
+def delete_requests(
+    ids: DeleteIds,
+    user: User = Depends(require_login),
+    db: Session = Depends(get_db),
+):
+    items = db.query(RequestItem).filter(RequestItem.id.in_(ids.ids)).all()
+    for it in items:
+        db.delete(it)
+    log_action(db, user.username, f"{len(items)} talep silindi")
+    db.commit()
+    return {"message": "deleted"}
 
 
 @app.post("/printer/add")

--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Aksesuar Takip{% endblock %}
+{% block content %}
+<h2>Aksesuar Takip</h2>
+<div class="d-flex gap-2 mb-3">
+  <button id="add-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+    <i class="bi bi-plus"></i>
+  </button>
+</div>
+<form>
+  <div id="rows" class="d-flex flex-column gap-2">
+    <div class="row g-2 item-row">
+      <div class="col">
+        <select class="form-select kategori">
+          <option value="donanim">Donanım</option>
+          <option value="lisans">Lisans</option>
+          <option value="aksesuar">Aksesuar</option>
+        </select>
+      </div>
+      <div class="col hardware-field">
+        <input type="text" class="form-control" placeholder="Donanım Tipi">
+      </div>
+      <div class="col hardware-field">
+        <input type="text" class="form-control" placeholder="Marka">
+      </div>
+      <div class="col hardware-field">
+        <input type="text" class="form-control" placeholder="Model">
+      </div>
+      <div class="col common-field">
+        <input type="number" class="form-control" placeholder="Adet">
+      </div>
+      <div class="col common-field">
+        <input type="text" class="form-control" placeholder="IFS No">
+      </div>
+      <div class="col license-field d-none">
+        <input type="text" class="form-control" placeholder="Yazılım Adı">
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}
+{% block scripts %}
+<script>
+function updateFields(row){
+  const cat = row.querySelector('.kategori').value;
+  row.querySelectorAll('.hardware-field').forEach(el=>el.classList.toggle('d-none', cat === 'lisans'));
+  row.querySelector('.license-field').classList.toggle('d-none', cat !== 'lisans');
+}
+document.querySelectorAll('.item-row').forEach(row=>{
+  updateFields(row);
+  row.querySelector('.kategori').addEventListener('change', ()=>updateFields(row));
+});
+document.getElementById('add-row').addEventListener('click', ()=>{
+  const rows = document.getElementById('rows');
+  const first = rows.querySelector('.item-row');
+  const clone = first.cloneNode(true);
+  clone.querySelectorAll('input').forEach(inp=>inp.value='');
+  rows.appendChild(clone);
+  updateFields(clone);
+  clone.querySelector('.kategori').addEventListener('change', ()=>updateFields(clone));
+});
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,6 +56,7 @@
       <li><a href="/printer"   class="{% if request.path.startswith('/printer') %}active{% endif %}">Yazıcı Takip</a></li>
       <li><a href="/stock"     class="{% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
       <li><a href="/requests" class="{% if request.path.startswith('/requests') %}active{% endif %}">Talep Takip</a></li>
+      <li><a href="/accessories" class="{% if request.path.startswith('/accessories') %}active{% endif %}">Aksesuar Takip</a></li>
       <li><a href="/trash" class="{% if request.path.startswith('/trash') %}active{% endif %}">Çöp Kutusu</a></li>
       <li><a href="/lists" class="{% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
       {% if request.session.get('is_admin') %}

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -10,6 +10,7 @@
     <i class="bi bi-plus"></i>
   </button>
   <button id="transfer-selected" type="button" class="btn btn-primary" style="height:40px;">Giriş</button>
+  <button id="delete-selected" type="button" class="btn btn-danger" style="height:40px;">Sil</button>
 </div>
 
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
@@ -66,9 +67,11 @@
     <tr>
       <td><input class="form-check-input row-check" type="checkbox" value="{{ items[0].id }}"></td>
       <td>
+        {% if items|length > 1 %}
         <button type="button" class="btn btn-link p-0 toggle-group" data-group="{{ ifs }}">
           <i class="bi bi-caret-right-fill"></i>
         </button>
+        {% endif %}
         {{ items[0].urun_adi }}
       </td>
       <td>{{ items[0].adet }}</td>
@@ -104,6 +107,18 @@ document.getElementById('transfer-selected').addEventListener('click', function(
     return;
   }
   fetch('/requests/transfer', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ids: ids})
+  }).then(r => r.json()).then(() => location.reload());
+});
+document.getElementById('delete-selected').addEventListener('click', function(){
+  const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => parseInt(cb.value));
+  if(!ids.length){
+    showAlert('Lütfen kayıt seçin');
+    return;
+  }
+  fetch('/requests/delete', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ids: ids})


### PR DESCRIPTION
## Summary
- Add navigation link and route for new Aksesuar Takip page with dynamic fields
- Allow deleting selected requests and hide group toggle when only one item

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6888c3dc832b90d95d40fd160177