### PR TITLE
Prompt for missing fields when transferring requests to stock

### DIFF
--- a/templates/talep.html
+++ b/templates/talep.html
@@ -62,6 +62,23 @@
           <button type="submit" class="btn btn-success">Kaydet</button>
         </div>
       </form>
+</div>
+</div>
+</div>
+
+<div class="modal fade" id="transferModal" tabindex="-1" aria-labelledby="transferModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="transferModalLabel">Eksik Bilgileri Girin</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <div id="transfer-rows" class="d-flex flex-column gap-2"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" id="confirm-transfer" class="btn btn-primary">Kaydet</button>
+      </div>
     </div>
   </div>
 </div>
@@ -114,15 +131,40 @@ document.getElementById('select-all').addEventListener('change', function(){
   document.querySelectorAll('.row-check').forEach(cb => cb.checked = this.checked);
 });
 document.getElementById('transfer-selected').addEventListener('click', function(){
-  const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => parseInt(cb.value));
-  if(!ids.length){
+  const checks = Array.from(document.querySelectorAll('.row-check:checked'));
+  if(!checks.length){
     showAlert('Lütfen kayıt seçin');
     return;
   }
+  const container = document.getElementById('transfer-rows');
+  container.innerHTML = '';
+  checks.forEach(cb => {
+    const tr = cb.closest('tr');
+    const urun = tr.children[1].innerText.trim();
+    const div = document.createElement('div');
+    div.className = 'row g-2 transfer-row';
+    div.innerHTML = `
+      <input type="hidden" name="id" value="${cb.value}">
+      <div class="col">${urun}</div>
+      <div class="col"><input type="text" class="form-control kategori" placeholder="Kategori"></div>
+      <div class="col"><input type="text" class="form-control departman" placeholder="Departman"></div>
+    `;
+    container.appendChild(div);
+  });
+  const modal = new bootstrap.Modal(document.getElementById('transferModal'));
+  modal.show();
+});
+document.getElementById('confirm-transfer').addEventListener('click', function(){
+  const rows = document.querySelectorAll('#transfer-rows .transfer-row');
+  const items = Array.from(rows).map(row => ({
+    id: parseInt(row.querySelector('input[name="id"]').value),
+    kategori: row.querySelector('.kategori').value,
+    departman: row.querySelector('.departman').value
+  }));
   fetch('/requests/transfer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ids: ids})
+    body: JSON.stringify({items: items})
   }).then(r => r.json()).then(() => location.reload());
 });
 document.getElementById('delete-selected').addEventListener('click', function(){


### PR DESCRIPTION
## Summary
- Add TransferItem models to collect category and department details during request transfer
- Prompt user for missing info with new modal before moving requests to stock
- Record transfers with supplied category and department values

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c6bc822a8832bab460ad7f7fb3016