### PR TITLE
Allow specifying quantity for request-to-stock transfer

### DIFF
--- a/main.py
+++ b/main.py
@@ -491,6 +491,7 @@ class TransferItem(BaseModel):
     id: int
     kategori: Optional[str] = ""
     departman: Optional[str] = ""
+    adet: Optional[int] = None
 
 
 class TransferItems(BaseModel):
@@ -1958,7 +1959,7 @@ def transfer_requests(
             urun_adi=it.urun_adi,
             kategori=inp.kategori,
             marka="",
-            adet=it.adet,
+            adet=inp.adet if inp.adet is not None else it.adet,
             departman=inp.departman,
             guncelleme_tarihi=date.today(),
             islem="Giriş",

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -146,6 +146,7 @@ document.getElementById('transfer-selected').addEventListener('click', function(
     div.innerHTML = `
       <input type="hidden" name="id" value="${cb.value}">
       <div class="col">${urun}</div>
+      <div class="col"><input type="number" class="form-control adet" placeholder="Adet" value="${tr.children[2].innerText.trim()}"></div>
       <div class="col"><input type="text" class="form-control kategori" placeholder="Kategori"></div>
       <div class="col"><input type="text" class="form-control departman" placeholder="Departman"></div>
     `;
@@ -159,7 +160,8 @@ document.getElementById('confirm-transfer').addEventListener('click', function()
   const items = Array.from(rows).map(row => ({
     id: parseInt(row.querySelector('input[name="id"]').value),
     kategori: row.querySelector('.kategori').value,
-    departman: row.querySelector('.departman').value
+    departman: row.querySelector('.departman').value,
+    adet: parseInt(row.querySelector('.adet').value)
   }));
   fetch('/requests/transfer', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Allow setting quantity when moving requests into stock
- Record provided quantity on backend via new `adet` field

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c6d7cb164832bbb78ea9b48a56c5d