### PR TITLE
Add accessory tracking and routing

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,6 +153,18 @@ class StockItem(Base):
     islem_yapan = Column(String)
 
 
+class AccessoryInventory(Base):
+    __tablename__ = "accessory_inventory"
+    id = Column(Integer, primary_key=True, index=True)
+    urun_adi = Column(String)
+    adet = Column(Integer)
+    tarih = Column(Date)
+    ifs_no = Column(String)
+    departman = Column(String)
+    kullanici = Column(String)
+    aciklama = Column(String)
+
+
 class RequestItem(Base):
     __tablename__ = "request_tracking"
     id = Column(Integer, primary_key=True, index=True)
@@ -1938,8 +1950,10 @@ def request_tracking_page(
 def accessories_page(
     request: Request,
     user: User = Depends(require_login),
+    db: Session = Depends(get_db),
 ):
-    return templates.TemplateResponse("aksesuar.html", {"request": request})
+    items = db.query(AccessoryInventory).order_by(AccessoryInventory.tarih.desc()).all()
+    return templates.TemplateResponse("aksesuar.html", {"request": request, "items": items})
 
 
 @app.post("/requests/add")
@@ -2035,6 +2049,17 @@ def transfer_requests(
                     bagli_makina_no="",
                 )
                 db.add(hw)
+        elif it.kategori == "aksesuar":
+            acc = AccessoryInventory(
+                urun_adi=it.urun_adi,
+                adet=qty,
+                tarih=date.today(),
+                ifs_no=it.ifs_no,
+                departman=inp.departman,
+                kullanici=it.talep_acan,
+                aciklama=it.aciklama,
+            )
+            db.add(acc)
         else:
             st = StockItem(
                 urun_adi=it.urun_adi,

--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -1,63 +1,34 @@
 {% extends "base.html" %}
 {% block title %}Aksesuar Takip{% endblock %}
 {% block content %}
-<h2>Aksesuar Takip</h2>
-<div class="d-flex gap-2 mb-3">
-  <button id="add-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
-    <i class="bi bi-plus"></i>
-  </button>
+<div class="d-flex justify-content-between align-items-center">
+  <h2>Aksesuar Takip</h2>
+  <span class="badge bg-secondary">{{ items|length }} kayıt var</span>
 </div>
-<form>
-  <div id="rows" class="d-flex flex-column gap-2">
-    <div class="row g-2 item-row">
-      <div class="col">
-        <select class="form-select kategori">
-          <option value="donanim">Donanım</option>
-          <option value="lisans">Lisans</option>
-          <option value="aksesuar">Aksesuar</option>
-        </select>
-      </div>
-      <div class="col hardware-field">
-        <input type="text" class="form-control" placeholder="Donanım Tipi">
-      </div>
-      <div class="col hardware-field">
-        <input type="text" class="form-control" placeholder="Marka">
-      </div>
-      <div class="col hardware-field">
-        <input type="text" class="form-control" placeholder="Model">
-      </div>
-        <div class="col common-field">
-          <input type="number" class="form-control" placeholder="Adet" min="0">
-        </div>
-      <div class="col common-field">
-        <input type="text" class="form-control" placeholder="IFS No">
-      </div>
-      <div class="col license-field d-none">
-        <input type="text" class="form-control" placeholder="Yazılım Adı">
-      </div>
-    </div>
-  </div>
-</form>
-{% endblock %}
-{% block scripts %}
-<script>
-function updateFields(row){
-  const cat = row.querySelector('.kategori').value;
-  row.querySelectorAll('.hardware-field').forEach(el=>el.classList.toggle('d-none', cat === 'lisans'));
-  row.querySelector('.license-field').classList.toggle('d-none', cat !== 'lisans');
-}
-document.querySelectorAll('.item-row').forEach(row=>{
-  updateFields(row);
-  row.querySelector('.kategori').addEventListener('change', ()=>updateFields(row));
-});
-document.getElementById('add-row').addEventListener('click', ()=>{
-  const rows = document.getElementById('rows');
-  const first = rows.querySelector('.item-row');
-  const clone = first.cloneNode(true);
-  clone.querySelectorAll('input').forEach(inp=>inp.value='');
-  rows.appendChild(clone);
-  updateFields(clone);
-  clone.querySelector('.kategori').addEventListener('change', ()=>updateFields(clone));
-});
-</script>
+<table class="table table-striped mt-3">
+  <thead>
+    <tr>
+      <th>Ürün Adı</th>
+      <th>Adet</th>
+      <th>Tarih</th>
+      <th>IFS No</th>
+      <th>Departman</th>
+      <th>Kullanıcı</th>
+      <th>Açıklama</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for it in items %}
+    <tr>
+      <td>{{ it.urun_adi }}</td>
+      <td>{{ it.adet }}</td>
+      <td>{{ it.tarih }}</td>
+      <td>{{ it.ifs_no }}</td>
+      <td>{{ it.departman }}</td>
+      <td>{{ it.kullanici }}</td>
+      <td>{{ it.aciklama }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add AccessoryInventory model and accessory tracking page
- Route request transfers to accessory tracking when category is 'aksesuar'
- Display accessory records with product, quantity, date, IFS number, department, user and description

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c771e91b4832b93d131f138ab8b64