### PR TITLE
Ensure transfer form fields are completed before processing

### DIFF
--- a/main.py
+++ b/main.py
@@ -519,7 +519,7 @@ class DeleteIds(BaseModel):
 
 class TransferItem(BaseModel):
     id: int
-    departman: Optional[str] = ""
+    departman: str = Field(..., min_length=1)
     adet: Optional[int] = None
 
 

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -196,11 +196,23 @@ document.getElementById('transfer-selected').addEventListener('click', function(
 });
 document.getElementById('confirm-transfer').addEventListener('click', function(){
   const rows = document.querySelectorAll('#transfer-rows .transfer-row');
-  const items = Array.from(rows).map(row => ({
-    id: parseInt(row.querySelector('input[name="id"]').value),
-    departman: row.querySelector('.departman').value,
-    adet: parseInt(row.querySelector('.adet').value)
-  }));
+  let valid = true;
+  const items = Array.from(rows).map(row => {
+    const departman = row.querySelector('.departman').value.trim();
+    const adet = parseInt(row.querySelector('.adet').value);
+    if(!departman || isNaN(adet)){
+      valid = false;
+    }
+    return {
+      id: parseInt(row.querySelector('input[name="id"]').value),
+      departman: departman,
+      adet: adet
+    };
+  });
+  if(!valid){
+    showAlert('Lütfen tüm alanları doldurun');
+    return;
+  }
   fetch('/requests/transfer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## Summary
- validate transfer items on server by requiring departman field
- block request transfers unless all fields are filled in the modal

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c95d2eae4832bac65f3483ed12b68