### PR TITLE
Enable horizontal scrolling for inventory table

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,8 @@
   <style>
     *{ box-sizing: border-box; }
     body{ margin:0; font-family: Arial, sans-serif; color:#111; }
-    .table-fixed{ table-layout:auto; width:100%; }
+    .table-container{ width:100%; overflow-x:auto; }
+    .table-fixed{ table-layout:auto; width:max-content; min-width:100%; }
     .table-fixed td{ white-space:normal; word-break:break-word; }
     .table-resizable th,
     .table-resizable td{ border-right:1px solid #dee2e6; }

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -149,6 +149,7 @@
   </div>
 </div>
 
+<div class="table-container">
 <table class="table table-striped table-fixed table-resizable">
     <tr>
         <th><input type="checkbox" id="select-all"></th>
@@ -167,6 +168,7 @@
     </tr>
     {% endfor %}
 </table>
+</div>
 
 <nav aria-label="Sayfalar">
   <ul class="pagination justify-content-center">


### PR DESCRIPTION
## Summary
- Allow tables to overflow horizontally by default
- Wrap inventory table in scrollable container to keep columns readable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca48b44d0832ba1c11f8d0c0c7df2