### PR TITLE
Remove Prometheus and Grafana integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,19 +11,3 @@ services:
     volumes:
       - ./data:/app/data
       - ./image:/app/image     # hosttaki image klasörünü container’a bağla
-
-  prometheus:
-    image: prom/prometheus
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9090:9090"
-    depends_on:
-      - envanter
-
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "3000:3000"
-    depends_on:
-      - prometheus

--- a/main.py
+++ b/main.py
@@ -23,7 +23,6 @@ from passlib.context import CryptContext
 from passlib.exc import UnknownHashError
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
-from prometheus_fastapi_instrumentator import Instrumentator
 
 # --- DATABASE AYARI (Docker icin degisebilir) ---
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -674,9 +673,6 @@ class TransferItems(BaseModel):
 # --- FastAPI Uygulaması ---
 app = FastAPI()
 app.mount("/image", StaticFiles(directory="image"), name="image")
-
-# Expose Prometheus metrics at /metrics
-Instrumentator().instrument(app).expose(app)
 templates = Jinja2Templates(directory="templates")
 
 # Oturum yönetimi için SessionMiddleware ekle

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,7 +1,0 @@
-global:
-  scrape_interval: 15s
-
-scrape_configs:
-  - job_name: 'envanter'
-    static_configs:
-      - targets: ['envanter:5000']

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ openpyxl
 passlib[bcrypt]
 bcrypt<4.0
 sentry-sdk
-prometheus-fastapi-instrumentator


### PR DESCRIPTION
## Summary
- remove Prometheus and Grafana services from docker-compose
- drop Prometheus instrumentation and dependency
- delete unused Prometheus configuration

## Testing
- `python -m py_compile main.py`
- `docker compose config` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce878b1b4832ba42c9424b537b4c1