### PR TITLE
Add multi-filter search and quantity prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -1029,6 +1029,7 @@ def inventory_page(
     page: int = 1,
     per_page: int = 50,
     q: str = "",
+    q2: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1046,6 +1047,9 @@ def inventory_page(
     if q:
         pattern = f"%{q}%"
         query = query.filter(or_(*(getattr(HardwareInventory, c).ilike(pattern) for c in columns)))
+    if q2:
+        pattern2 = f"%{q2}%"
+        query = query.filter(or_(*(getattr(HardwareInventory, c).ilike(pattern2) for c in columns)))
     total = query.count()
     total_pages = (total + per_page - 1) // per_page or 1
     if page > total_pages:
@@ -1087,6 +1091,7 @@ def inventory_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "q2": q2,
             "offset": offset,
             "lookups": lookups,
         },
@@ -1430,6 +1435,7 @@ def license_page(
     page: int = 1,
     per_page: int = 50,
     q: str = "",
+    q2: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1447,6 +1453,9 @@ def license_page(
     if q:
         pattern = f"%{q}%"
         query = query.filter(or_(*(getattr(LicenseInventory, c).ilike(pattern) for c in columns)))
+    if q2:
+        pattern2 = f"%{q2}%"
+        query = query.filter(or_(*(getattr(LicenseInventory, c).ilike(pattern2) for c in columns)))
     total = query.count()
     total_pages = (total + per_page - 1) // per_page or 1
     if page > total_pages:
@@ -1483,6 +1492,7 @@ def license_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "q2": q2,
             "offset": offset,
             "lookups": lookups,
         },
@@ -1750,6 +1760,7 @@ def stock_page(
     page: int = 0,
     per_page: int = 50,
     q: str = "",
+    q2: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -1766,6 +1777,9 @@ def stock_page(
     if q:
         pattern = f"%{q}%"
         query = query.filter(or_(*(getattr(StockItem, c).ilike(pattern) for c in columns)))
+    if q2:
+        pattern2 = f"%{q2}%"
+        query = query.filter(or_(*(getattr(StockItem, c).ilike(pattern2) for c in columns)))
     total = query.count()
     total_pages = (total + per_page - 1) // per_page or 1
     if page < 1:
@@ -1798,6 +1812,7 @@ def stock_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "q2": q2,
             "offset": offset,
             "lookups": lookups,
         },
@@ -2059,6 +2074,7 @@ def printer_page(
     page: int = 1,
     per_page: int = 50,
     q: str = "",
+    q2: str = "",
     user: User = Depends(require_login),
     db: Session = Depends(get_db),
 ):
@@ -2076,6 +2092,9 @@ def printer_page(
     if q:
         pattern = f"%{q}%"
         query = query.filter(or_(*(getattr(PrinterInventory, c).ilike(pattern) for c in columns)))
+    if q2:
+        pattern2 = f"%{q2}%"
+        query = query.filter(or_(*(getattr(PrinterInventory, c).ilike(pattern2) for c in columns)))
     total = query.count()
     total_pages = (total + per_page - 1) // per_page or 1
     if page > total_pages:
@@ -2111,6 +2130,7 @@ def printer_page(
             "total_pages": total_pages,
             "per_page": per_page,
             "q": q,
+            "q2": q2,
             "offset": offset,
             "lookups": lookups,
         },

--- a/templates/base.html
+++ b/templates/base.html
@@ -96,12 +96,28 @@
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('table.table-resizable').forEach(makeTableResizable);
       const searchForm = document.getElementById('search-form');
-      const searchInput = document.getElementById('search-input');
-      if (searchForm && searchInput) {
+      const searchInputs = document.querySelectorAll('.search-input');
+      if (searchForm && searchInputs.length) {
         let searchTimeout;
-        searchInput.addEventListener('input', () => {
-          clearTimeout(searchTimeout);
-          searchTimeout = setTimeout(() => searchForm.submit(), 500);
+        searchInputs.forEach(inp => {
+          inp.addEventListener('input', () => {
+            clearTimeout(searchTimeout);
+            searchTimeout = setTimeout(() => searchForm.submit(), 500);
+          });
+        });
+      }
+      const addFilterBtn = document.getElementById('add-filter');
+      if (addFilterBtn) {
+        addFilterBtn.addEventListener('click', () => {
+          const second = document.getElementById('search-input-2');
+          if (second.classList.contains('d-none')) {
+            second.classList.remove('d-none');
+            second.focus();
+          } else {
+            second.value = '';
+            second.classList.add('d-none');
+            if (searchForm) searchForm.submit();
+          }
         });
       }
       const perPage = document.getElementById('per-page');

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -45,8 +45,12 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
-    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center">
+    <input id="search-input" name="q" type="text" class="form-control search-input" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-search"></i>
+    </button>
+    <input id="search-input-2" name="q2" type="text" class="form-control search-input {% if not q2 %}d-none{% endif %}" placeholder="Ara..." value="{{ q2 }}" style="max-width: 200px;">
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}
       <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -28,8 +28,12 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
-    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center">
+    <input id="search-input" name="q" type="text" class="form-control search-input" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-search"></i>
+    </button>
+    <input id="search-input-2" name="q2" type="text" class="form-control search-input {% if not q2 %}d-none{% endif %}" placeholder="Ara..." value="{{ q2 }}" style="max-width: 200px;">
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}
       <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -28,15 +28,19 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <a class="btn btn-info" href="/stock/status" style="height:40px;display:flex;align-items:center;">Stok Durumu</a>
-  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
-    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center">
+    <input id="search-input" name="q" type="text" class="form-control search-input" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-search"></i>
+    </button>
+    <input id="search-input-2" name="q2" type="text" class="form-control search-input {% if not q2 %}d-none{% endif %}" placeholder="Ara..." value="{{ q2 }}" style="max-width: 200px;">
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}
       <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
       {% endfor %}
     </select>
   </form>
+  <a class="btn btn-info" href="/stock/status" style="height:40px;display:flex;align-items:center;">Stok Durumu</a>
 </div>
 
 <form id="uploadForm" action="/stock/upload" method="post" enctype="multipart/form-data" style="display:none;">

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -202,7 +202,7 @@ document.getElementById('transfer-selected').addEventListener('click', function(
       div.innerHTML = `
         <input type="hidden" name="id" value="${cb.value}">
         <div>${urun}</div>
-        <input type="number" class="form-control adet" placeholder="Adet" value="${maxQty}" min="1" max="${maxQty}">
+        <input type="number" class="form-control adet" placeholder="Adet" min="1" max="${maxQty}">
         <input type="text" class="form-control departman" placeholder="Departman">
         <input type="text" class="form-control kullanici" placeholder="Kullanıcı">
         <input type="text" class="form-control lisans_anahtari" placeholder="Lisans Anahtarı">
@@ -214,7 +214,7 @@ document.getElementById('transfer-selected').addEventListener('click', function(
       div.innerHTML = `
         <input type="hidden" name="id" value="${cb.value}">
         <div>${urun}</div>
-        <input type="number" class="form-control adet" placeholder="Adet" value="${maxQty}" min="1" max="${maxQty}">
+        <input type="number" class="form-control adet" placeholder="Adet" min="1" max="${maxQty}">
         <input type="text" class="form-control fabrika" placeholder="Fabrika">
         <input type="text" class="form-control blok" placeholder="Blok">
         <input type="text" class="form-control departman" placeholder="Departman">
@@ -242,7 +242,7 @@ document.getElementById('transfer-selected').addEventListener('click', function(
       div.innerHTML = `
         <input type="hidden" name="id" value="${cb.value}">
         <div>${urun}</div>
-        <input type="number" class="form-control adet" placeholder="Adet" value="${maxQty}" min="1" max="${maxQty}">
+        <input type="number" class="form-control adet" placeholder="Adet" min="1" max="${maxQty}">
         <input type="text" class="form-control departman" placeholder="Departman">
       `;
     }
@@ -348,7 +348,7 @@ document.getElementById('stock-transfer-selected').addEventListener('click', fun
     div.innerHTML = `
       <input type="hidden" name="id" value="${cb.value}">
       <div class="col">${urun}</div>
-      <div class="col"><input type="number" class="form-control adet" placeholder="Adet" value="${maxQty}" min="1" max="${maxQty}"></div>
+      <div class="col"><input type="number" class="form-control adet" placeholder="Adet" min="1" max="${maxQty}"></div>
     `;
     container.appendChild(div);
   });

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -28,8 +28,12 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="ms-auto d-flex gap-2">
-    <input id="search-input" name="q" type="text" class="form-control" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center">
+    <input id="search-input" name="q" type="text" class="form-control search-input" placeholder="Ara..." value="{{ q }}" style="max-width: 200px;">
+    <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-search"></i>
+    </button>
+    <input id="search-input-2" name="q2" type="text" class="form-control search-input {% if not q2 %}d-none{% endif %}" placeholder="Ara..." value="{{ q2 }}" style="max-width: 200px;">
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}
       <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>


### PR DESCRIPTION
## Summary
- Allow multiple search filters with a toggleable second query field and blue search icon
- Support filtering with two query strings across inventory, license, stock and printer pages
- Prompt for desired quantity before transferring requests

## Testing
- `python -m py_compile main.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689cea0fa6b8832bbc9009f16ef5712b