### PR TITLE
Define column labels in printer template

### DIFF
--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -1,4 +1,15 @@
 {% extends "base.html" %}
+{% set column_labels = {
+  'yazici_markasi': 'Yazıcı Markası',
+  'yazici_modeli': 'Yazıcı Modeli',
+  'kullanim_alani': 'Kullanım Alanı',
+  'ip_adresi': 'IP Adresi',
+  'mac': 'MAC',
+  'hostname': 'Hostname',
+  'tarih': 'Tarih',
+  'islem_yapan': 'İşlem Yapan',
+  'notlar': 'Notlar'
+} %}
 {% block title %}Yazıcı Takip{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## Summary
- Define column labels mapping in `yazici.html` so JavaScript receives valid data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf4201600832ba9bca53d64f27a91