### PR TITLE
Add persistent filter popup with clear option

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,17 @@
       top:0; right:0; width:5px; height:100%;
       cursor:col-resize; user-select:none;
     }
+    .filters-popup{
+      position:absolute;
+      top:50px;
+      left:0;
+      z-index:1000;
+      background:#fff;
+      border:1px solid #dee2e6;
+      padding:1rem;
+      border-radius:.25rem;
+      width:300px;
+    }
   </style>
 </head>
 <body>
@@ -100,6 +111,11 @@
       const filterRows = document.getElementById('filter-rows');
       const addFilterBtn = document.getElementById('add-filter');
       const addFilterRowBtn = document.getElementById('add-filter-row');
+      const clearFilterBtn = document.getElementById('clear-filter');
+      function updateClearBtn(){
+        if (!clearFilterBtn) return;
+        clearFilterBtn.classList.toggle('d-none', !filterRows || !filterRows.children.length);
+      }
       function addFilterRow(field = null, value = null){
         if (!filterRows) return;
         const row = document.createElement('div');
@@ -126,12 +142,14 @@
         removeBtn.textContent = '-';
         removeBtn.addEventListener('click', () => {
           row.remove();
+          updateClearBtn();
           if (searchForm) searchForm.submit();
         });
         row.appendChild(fieldSel);
         row.appendChild(valueSel);
         row.appendChild(removeBtn);
         filterRows.appendChild(row);
+        updateClearBtn();
         function loadValues(selected = null){
           if (!window.filterEndpoint || !window.tableName) return;
           fetch(`${window.filterEndpoint}?table_name=${encodeURIComponent(window.tableName)}&column=${encodeURIComponent(fieldSel.value)}`)
@@ -158,18 +176,25 @@
             filtersContainer.classList.remove('d-none');
             if (!filterRows.children.length) addFilterRow();
           } else {
-            filterRows.innerHTML = '';
             filtersContainer.classList.add('d-none');
-            if (searchForm) searchForm.submit();
           }
         });
       }
       if (addFilterRowBtn) {
         addFilterRowBtn.addEventListener('click', () => addFilterRow());
       }
+      if (clearFilterBtn) {
+        clearFilterBtn.addEventListener('click', () => {
+          if (filterRows) filterRows.innerHTML = '';
+          filtersContainer && filtersContainer.classList.add('d-none');
+          updateClearBtn();
+          if (searchForm) searchForm.submit();
+        });
+      }
       if (filtersContainer && window.initialFilters && window.initialFilters.length){
         filtersContainer.classList.remove('d-none');
         window.initialFilters.forEach(f => addFilterRow(f.field, f.value));
+        updateClearBtn();
       }
       const perPage = document.getElementById('per-page');
       if (perPage && searchForm) {
@@ -177,6 +202,7 @@
           searchForm.submit();
         });
       }
+      updateClearBtn();
     });
     function showAlert(message){
       document.getElementById('alertModalBody').innerText = message;

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -45,13 +45,16 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap">
-    <div id="filters-container" class="w-100 d-none flex-column gap-2">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap position-relative">
+    <div id="filters-container" class="filters-popup d-none flex-column gap-2">
       <div id="filter-rows" class="d-flex flex-column gap-2"></div>
       <button type="button" id="add-filter-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">+</button>
     </div>
     <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
       <i class="bi bi-search"></i>
+    </button>
+    <button id="clear-filter" type="button" class="btn btn-secondary d-none" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-x"></i>
     </button>
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -40,13 +40,16 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap">
-    <div id="filters-container" class="w-100 d-none flex-column gap-2">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap position-relative">
+    <div id="filters-container" class="filters-popup d-none flex-column gap-2">
       <div id="filter-rows" class="d-flex flex-column gap-2"></div>
       <button type="button" id="add-filter-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">+</button>
     </div>
     <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
       <i class="bi bi-search"></i>
+    </button>
+    <button id="clear-filter" type="button" class="btn btn-secondary d-none" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-x"></i>
     </button>
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -41,13 +41,16 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap">
-    <div id="filters-container" class="w-100 d-none flex-column gap-2">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap position-relative">
+    <div id="filters-container" class="filters-popup d-none flex-column gap-2">
       <div id="filter-rows" class="d-flex flex-column gap-2"></div>
       <button type="button" id="add-filter-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">+</button>
     </div>
     <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
       <i class="bi bi-search"></i>
+    </button>
+    <button id="clear-filter" type="button" class="btn btn-secondary d-none" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-x"></i>
     </button>
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -39,13 +39,16 @@
   <button id="delete-selected" type="button" class="btn btn-danger" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
     <i class="bi bi-trash"></i>
   </button>
-  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap">
-    <div id="filters-container" class="w-100 d-none flex-column gap-2">
+  <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-wrap position-relative">
+    <div id="filters-container" class="filters-popup d-none flex-column gap-2">
       <div id="filter-rows" class="d-flex flex-column gap-2"></div>
       <button type="button" id="add-filter-row" class="btn btn-success" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">+</button>
     </div>
     <button id="add-filter" type="button" class="btn btn-primary" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
       <i class="bi bi-search"></i>
+    </button>
+    <button id="clear-filter" type="button" class="btn btn-secondary d-none" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
+      <i class="bi bi-x"></i>
     </button>
     <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
       {% for opt in [25,50,100] %}


### PR DESCRIPTION
## Summary
- Show filters in a small popup below the search icon and keep selections when minimized
- Introduce "clear filter" button to remove all active filters and hide the popup

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf55be538832b8bfa66ba44f1ef04