### PR TITLE
Add LDAP-backed connections page and profile link

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ openpyxl
 passlib[bcrypt]
 bcrypt<4.0
 sentry-sdk
+ldap3

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,8 +52,10 @@
         <li><a href="/stock" class="nav-link text-white {% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
 
         <li class="nav-item mt-3"><span class="nav-link text-white text-uppercase fw-bold disabled">Ayarlar</span></li>
+        <li><a href="/profile" class="nav-link text-white {% if request.path.startswith('/profile') %}active{% endif %}">Profil</a></li>
         {% if request.session.get('is_admin') %}
         <li><a href="/admin" class="nav-link text-white {% if request.path.startswith('/admin') %}active{% endif %}">Admin Paneli</a></li>
+        <li><a href="/connections" class="nav-link text-white {% if request.path.startswith('/connections') %}active{% endif %}">Bağlantılar</a></li>
         {% endif %}
         <li><a href="/lists" class="nav-link text-white {% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
       </ul>

--- a/templates/connections.html
+++ b/templates/connections.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Bağlantılar{% endblock %}
+{% block content %}
+<h2>LDAP Bağlantısı</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+{% if success %}<div class="alert alert-success">{{ success }}</div>{% endif %}
+<form method="post" action="/connections">
+  <div class="mb-3">
+    <label class="form-label">Sunucu</label>
+    <input type="text" name="server" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Port</label>
+    <input type="number" name="port" class="form-control" value="389">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Kullanıcı DN</label>
+    <input type="text" name="user_dn" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şifre</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Base DN</label>
+    <input type="text" name="base_dn" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Kullanıcıları Çek</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Expose Profile option under Settings navigation
- Introduce admin-only Connections page to import users from LDAP
- Add ldap3 dependency for LDAP integration

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_689cf78c1fec832b8a7eb2c52d4e1b6f