### PR TITLE
Load admin credentials from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# BilgiislemTool
+
+## Environment Variables
+
+The application initializes an administrator account using credentials supplied via environment variables.
+
+- `ADMIN_USERNAME` – Username for the initial administrator.
+- `ADMIN_PASSWORD` – Password for the initial administrator.
+
+Both variables must be defined before the application starts. If either variable is missing, the application will exit with an error instead of creating the admin user.
+
+When using Docker Compose, provide these variables in your environment or an `.env` file:
+
+```
+ADMIN_USERNAME=your_admin_username
+ADMIN_PASSWORD=your_admin_password
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       - DATABASE_URL=sqlite:////app/data/envanter.db
       - SENTRY_DSN=${SENTRY_DSN:-}
+      - ADMIN_USERNAME
+      - ADMIN_PASSWORD
     volumes:
       - ./data:/app/data
       - ./image:/app/image     # hosttaki image klasörünü container’a bağla

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from starlette.middleware.sessions import SessionMiddleware
 import os
 import json
-import base64
 import sqlite3
 from passlib.context import CryptContext
 from passlib.exc import UnknownHashError
@@ -423,10 +422,14 @@ def init_db():
 
 
 def init_admin():
+    username = os.getenv("ADMIN_USERNAME")
+    password_plain = os.getenv("ADMIN_PASSWORD")
+    if not username or not password_plain:
+        raise RuntimeError(
+            "ADMIN_USERNAME and ADMIN_PASSWORD environment variables must be set"
+        )
     db = SessionLocal()
     try:
-        username = base64.b64decode("YWRtaW4=").decode()
-        password_plain = base64.b64decode("YWRtaW4=").decode()
         if not db.query(User).filter(User.username == username).first():
             admin = User(
                 username=username,


### PR DESCRIPTION
## Summary
- Read initial admin credentials from `ADMIN_USERNAME` and `ADMIN_PASSWORD`
- Pass admin credential variables through Docker Compose
- Document required admin credential environment variables

## Testing
- `python -m py_compile main.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfef452cc832bb250c7af7d71fc41