### PR TITLE
Add basic HTML routes and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ passlib[bcrypt]==1.7.4
 bcrypt==3.2.2
 sentry-sdk==2.34.1
 ldap3==2.9.1
+httpx==0.27.2

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,6 +1,28 @@
 from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
 
 router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+def root() -> str:
+    return "<h1>Welcome to BilgiislemTool</h1>"
+
+
+@router.get("/login", response_class=HTMLResponse)
+def login_page() -> str:
+    return "<h1>Login Page</h1>"
+
+
+@router.get("/stock", response_class=HTMLResponse)
+def stock_page() -> str:
+    return "<h1>Stock Page</h1>"
+
+
+@router.get("/printer", response_class=HTMLResponse)
+def printer_page() -> str:
+    return "<h1>Printer Page</h1>"
+
 
 @router.get("/ping")
 def ping():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,3 +31,10 @@ def test_ping_route():
     response = client.get("/ping")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_basic_pages():
+    client = TestClient(main.app)
+    for path in ["/", "/login", "/stock", "/printer"]:
+        resp = client.get(path)
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose basic HTML endpoints for root, login, stock and printer pages
- ensure httpx is installed for test client
- test that core pages and ping route respond as expected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d03842b64832b9b2930d770681fd9