### PR TITLE
Serve templates for basic routes

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,29 +1,78 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
+
+from utils import templates
 
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse)
-def root() -> str:
-    return "<h1>Welcome to BilgiislemTool</h1>"
+def root(request: Request) -> HTMLResponse:
+    """Render the main dashboard page.
+
+    The template expects a number of context variables. Provide
+    sensible defaults so the page can render even when the database
+    is empty or not yet configured.
+    """
+
+    context = {
+        "request": request,
+        "factories": {},
+        "actions": [],
+        "type_labels": [],
+        "type_counts": [],
+    }
+    return templates.TemplateResponse("main.html", context)
 
 
 @router.get("/login", response_class=HTMLResponse)
-def login_page() -> str:
-    return "<h1>Login Page</h1>"
+def login_page(request: Request, error: str | None = None) -> HTMLResponse:
+    """Render the login page."""
+
+    return templates.TemplateResponse("login.html", {"request": request, "error": error})
 
 
 @router.get("/stock", response_class=HTMLResponse)
-def stock_page() -> str:
-    return "<h1>Stock Page</h1>"
+def stock_page(request: Request) -> HTMLResponse:
+    """Render the stock tracking page with empty defaults."""
+
+    context = {
+        "request": request,
+        "stocks": [],
+        "columns": [],
+        "column_widths": {},
+        "lookups": {},
+        "offset": 0,
+        "page": 1,
+        "total_pages": 1,
+        "q": "",
+        "per_page": 25,
+        "table_name": "stock",
+        "filters": [],
+    }
+    return templates.TemplateResponse("stok.html", context)
 
 
 @router.get("/printer", response_class=HTMLResponse)
-def printer_page() -> str:
-    return "<h1>Printer Page</h1>"
+def printer_page(request: Request) -> HTMLResponse:
+    """Render the printer inventory page with empty defaults."""
+
+    context = {
+        "request": request,
+        "printers": [],
+        "columns": [],
+        "column_widths": {},
+        "offset": 0,
+        "page": 1,
+        "total_pages": 1,
+        "q": "",
+        "per_page": 25,
+        "table_name": "printer",
+        "filters": [],
+    }
+    return templates.TemplateResponse("yazici.html", context)
 
 
 @router.get("/ping")
-def ping():
+def ping() -> dict[str, str]:
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- Render Jinja2 templates for root, login, stock, and printer endpoints
- Provide default context data so pages display even without database content

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d054c106c832bb81a396dab39518f