### PR TITLE
Use absolute template path for FastAPI templates

### DIFF
--- a/tests/test_template_path.py
+++ b/tests/test_template_path.py
@@ -1,0 +1,13 @@
+import sys
+import importlib
+from pathlib import Path
+
+
+def test_templates_resolve_from_any_cwd(tmp_path, monkeypatch):
+    project_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(project_root))
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("utils", None)
+    utils = importlib.import_module("utils")
+    assert utils.templates.env.get_template("login.html") is not None
+    sys.path.remove(str(project_root))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,7 @@
 import os
 import json
 from datetime import date, timedelta
+from pathlib import Path
 from typing import List
 
 from fastapi.templating import Jinja2Templates
@@ -16,8 +17,9 @@ from models import (
     DeletedStockItem,
 )
 
-# Reusable Jinja2 template loader
-templates = Jinja2Templates(directory="templates")
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+# Reusable Jinja2 template loader using an absolute path
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 # Settings file path used by load_settings/save_settings
 SETTINGS_FILE = os.path.join(


### PR DESCRIPTION
## Summary
- Resolve an absolute templates directory with `Path(__file__).resolve().parent.parent / "templates"`
- Pass the resolved path to `Jinja2Templates`
- Add regression test ensuring templates are found even when cwd changes before importing utils

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da05b9348832baef537174e39ca53