### PR TITLE
Add admin management routes and admin authorization checks

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -5,10 +5,12 @@ from fastapi import APIRouter
 from .auth import router as auth_router
 from .inventory import router as inventory_router
 from .reporting import router as reporting_router
+from .admin import router as admin_router
 
 router = APIRouter()
 router.include_router(auth_router)
 router.include_router(inventory_router)
 router.include_router(reporting_router)
+router.include_router(admin_router)
 
 __all__ = ["router"]

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,0 +1,130 @@
+"""Admin management routes."""
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from models import SessionLocal, User, pwd_context
+from utils import templates
+from utils.auth import require_admin
+
+router = APIRouter(dependencies=[Depends(require_admin)])
+
+
+@router.get("/admin", response_class=HTMLResponse)
+def admin_page(request: Request) -> HTMLResponse:
+    """List all users."""
+    db = SessionLocal()
+    try:
+        users = db.query(User).all()
+    finally:
+        db.close()
+    return templates.TemplateResponse(request, "admin.html", {"users": users})
+
+
+@router.post("/admin/create")
+def create_user(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    first_name: str = Form(None),
+    last_name: str = Form(None),
+    email: str = Form(None),
+    is_admin: bool = Form(False),
+):
+    """Create a new user."""
+    db = SessionLocal()
+    try:
+        if db.query(User).filter(User.username == username).first():
+            users = db.query(User).all()
+            return templates.TemplateResponse(
+                request,
+                "admin.html",
+                {"users": users, "error": "Kullanıcı mevcut"},
+                status_code=400,
+            )
+        user = User(
+            username=username,
+            password=pwd_context.hash(password),
+            is_admin=is_admin,
+            first_name=first_name,
+            last_name=last_name,
+            email=email,
+        )
+        db.add(user)
+        db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/admin", status_code=303)
+
+
+@router.post("/admin/make_admin/{user_id}")
+def make_admin(user_id: int):
+    """Promote a user to admin."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).get(user_id)
+        if user:
+            user.is_admin = True
+            db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/admin", status_code=303)
+
+
+@router.get("/admin/edit/{user_id}", response_class=HTMLResponse)
+def edit_user_form(request: Request, user_id: int) -> HTMLResponse:
+    """Render the edit form for a user."""
+    db = SessionLocal()
+    try:
+        target = db.query(User).get(user_id)
+    finally:
+        db.close()
+    if not target:
+        return RedirectResponse("/admin", status_code=303)
+    return templates.TemplateResponse(
+        request, "admin_edit.html", {"target": target}
+    )
+
+
+@router.post("/admin/edit/{user_id}")
+def edit_user(
+    user_id: int,
+    password: str = Form(None),
+    first_name: str = Form(None),
+    last_name: str = Form(None),
+    email: str = Form(None),
+    is_admin: bool = Form(False),
+):
+    """Update a user's details."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).get(user_id)
+        if user:
+            if password:
+                user.password = pwd_context.hash(password)
+                user.must_change_password = True
+            user.first_name = first_name
+            user.last_name = last_name
+            user.email = email
+            user.is_admin = is_admin
+            db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/admin", status_code=303)
+
+
+@router.post("/admin/delete/{user_id}")
+def delete_user(user_id: int):
+    """Delete a user."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).get(user_id)
+        if user:
+            db.delete(user)
+            db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/admin", status_code=303)
+
+
+__all__ = ["router"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,11 +16,17 @@ import main
 from models import SessionLocal, User, init_db, pwd_context
 
 
-def create_user(username: str = "tester", password: str = "secret"):
+def create_user(username: str = "tester", password: str = "secret", is_admin: bool = False):
     init_db()
     db = SessionLocal()
     if not db.query(User).filter_by(username=username).first():
-        db.add(User(username=username, password=pwd_context.hash(password)))
+        db.add(
+            User(
+                username=username,
+                password=pwd_context.hash(password),
+                is_admin=is_admin,
+            )
+        )
         db.commit()
     db.close()
 
@@ -53,3 +59,43 @@ def test_login_creates_session_and_logout_clears_it():
 
     resp = client.get("/ping")
     assert resp.status_code == 401
+
+
+def test_admin_routes_require_admin():
+    create_user("admin_user", is_admin=True)
+    create_user("normal_user", password="secret2", is_admin=False)
+    client = TestClient(main.app)
+
+    # non-admin should get forbidden
+    client.post(
+        "/login", data={"username": "normal_user", "password": "secret2"}, follow_redirects=False
+    )
+    resp = client.get("/admin", follow_redirects=False)
+    assert resp.status_code == 403
+
+    # switch to admin
+    client.post("/logout", follow_redirects=False)
+    client.post(
+        "/login", data={"username": "admin_user", "password": "secret"}, follow_redirects=False
+    )
+    resp = client.get("/admin")
+    assert resp.status_code == 200
+
+
+def test_admin_can_create_user():
+    create_user("site_admin", is_admin=True)
+    client = TestClient(main.app)
+    client.post(
+        "/login", data={"username": "site_admin", "password": "secret"}, follow_redirects=False
+    )
+
+    resp = client.post(
+        "/admin/create", data={"username": "new_user", "password": "pass"}, follow_redirects=False
+    )
+    assert resp.status_code == 303
+
+    db = SessionLocal()
+    try:
+        assert db.query(User).filter_by(username="new_user").first() is not None
+    finally:
+        db.close()

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -15,3 +15,22 @@ def require_login(request: Request):
             raise HTTPException(status_code=303, headers={"Location": "/login"})
         raise HTTPException(status_code=401)
     return None
+
+
+def require_admin(request: Request):
+    """Ensure the current session belongs to an admin user."""
+    # First confirm the user is logged in.
+    require_login(request)
+
+    # Import locally to avoid circular imports during application start-up.
+    from models import SessionLocal, User
+
+    db = SessionLocal()
+    try:
+        user_id = request.session.get("user_id")
+        user = db.query(User).get(user_id)
+        if not user or not user.is_admin:
+            raise HTTPException(status_code=403)
+    finally:
+        db.close()
+    return None


### PR DESCRIPTION
## Summary
- implement admin-only FastAPI router for user management (list, create, promote, edit, delete)
- add `require_admin` dependency built on existing login check
- register admin router and expand tests for admin access and user creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da74e2aac832ba8f21d8803a33b20