### PR TITLE
Add dedicated hardware and stock routers with tests

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,13 +3,15 @@
 from fastapi import APIRouter
 
 from .auth import router as auth_router
-from .inventory import router as inventory_router
+from .hardware import router as hardware_router
+from .stock import router as stock_router
 from .reporting import router as reporting_router
 from .admin import router as admin_router
 
 router = APIRouter()
 router.include_router(auth_router)
-router.include_router(inventory_router)
+router.include_router(hardware_router, prefix="/hardware")
+router.include_router(stock_router, prefix="/stock")
 router.include_router(reporting_router)
 router.include_router(admin_router)
 

--- a/routes/hardware.py
+++ b/routes/hardware.py
@@ -1,0 +1,59 @@
+"""Hardware inventory routes."""
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from utils.auth import require_login
+from utils import templates, get_table_columns
+from models import HardwareInventory, SessionLocal
+
+router = APIRouter(dependencies=[Depends(require_login)])
+
+
+@router.get("", response_class=HTMLResponse)
+def list_hardware(request: Request) -> HTMLResponse:
+    """Render hardware inventory list."""
+    db = SessionLocal()
+    try:
+        items = db.query(HardwareInventory).all()
+    finally:
+        db.close()
+    context = {
+        "request": request,
+        "items": items,
+        "columns": get_table_columns(HardwareInventory.__tablename__),
+        "column_widths": {},
+        "lookups": {},
+        "offset": 0,
+        "page": 1,
+        "total_pages": 1,
+        "q": "",
+        "per_page": 25,
+        "table_name": "hardware",
+        "filters": [],
+        "count": len(items),
+    }
+    return templates.TemplateResponse("envanter.html", context)
+
+
+@router.post("/add")
+async def add_hardware(request: Request):
+    """Add a hardware inventory record."""
+    form = await request.form()
+    db = SessionLocal()
+    try:
+        item = HardwareInventory(
+            no=form.get("no"),
+            donanim_tipi=form.get("donanim_tipi"),
+            marka=form.get("marka"),
+            model=form.get("model"),
+            seri_no=form.get("seri_no"),
+            tarih=date.fromisoformat(form.get("tarih")) if form.get("tarih") else None,
+        )
+        db.add(item)
+        db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/hardware", status_code=303)

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -1,0 +1,64 @@
+"""Stock tracking routes."""
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from utils.auth import require_login
+from utils import templates, get_table_columns
+from models import StockItem, SessionLocal
+
+router = APIRouter(dependencies=[Depends(require_login)])
+
+
+@router.get("", response_class=HTMLResponse)
+def list_stock(request: Request) -> HTMLResponse:
+    """Render stock list."""
+    db = SessionLocal()
+    try:
+        stocks = db.query(StockItem).all()
+    finally:
+        db.close()
+    context = {
+        "request": request,
+        "stocks": stocks,
+        "columns": get_table_columns(StockItem.__tablename__),
+        "column_widths": {},
+        "lookups": {},
+        "offset": 0,
+        "page": 1,
+        "total_pages": 1,
+        "q": "",
+        "per_page": 25,
+        "table_name": "stock",
+        "filters": [],
+        "count": len(stocks),
+    }
+    return templates.TemplateResponse("stok.html", context)
+
+
+@router.post("/add")
+async def add_stock(request: Request):
+    """Add a stock item."""
+    form = await request.form()
+    db = SessionLocal()
+    try:
+        item = StockItem(
+            urun_adi=form.get("urun_adi"),
+            adet=int(form.get("adet") or 0),
+            kategori=form.get("kategori"),
+            marka=form.get("marka"),
+            departman=form.get("departman"),
+            guncelleme_tarihi=date.fromisoformat(form.get("guncelleme_tarihi")) if form.get("guncelleme_tarihi") else None,
+            islem=form.get("islem"),
+            tarih=date.fromisoformat(form.get("tarih")) if form.get("tarih") else None,
+            ifs_no=form.get("ifs_no"),
+            aciklama=form.get("aciklama"),
+            islem_yapan=form.get("islem_yapan"),
+        )
+        db.add(item)
+        db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/stock", status_code=303)

--- a/tests/test_inventory_routes.py
+++ b/tests/test_inventory_routes.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from starlette.middleware.sessions import SessionMiddleware
+
+import models
+from routes.hardware import router as hardware_router
+from routes.stock import router as stock_router
+from utils.auth import require_login
+
+
+def create_app():
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test")
+    app.include_router(hardware_router, prefix="/hardware")
+    app.include_router(stock_router, prefix="/stock")
+    # Bypass authentication for tests
+    app.dependency_overrides[require_login] = lambda: None
+    return app
+
+
+def setup_in_memory_db():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.engine = engine
+    models.SessionLocal = TestingSessionLocal
+    models.Base.metadata.create_all(bind=engine)
+
+
+def test_hardware_router_lists_added_items():
+    setup_in_memory_db()
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/hardware/add",
+        data={"no": "001", "donanim_tipi": "Laptop"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    resp = client.get("/hardware")
+    assert resp.status_code == 200
+    assert "Laptop" in resp.text
+
+
+def test_stock_router_lists_added_items():
+    setup_in_memory_db()
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/stock/add", data={"urun_adi": "Mouse", "adet": "5"}, follow_redirects=False
+    )
+    assert resp.status_code == 303
+    resp = client.get("/stock")
+    assert resp.status_code == 200
+    assert "Mouse" in resp.text


### PR DESCRIPTION
## Summary
- Introduce `hardware` router for listing and adding hardware inventory items
- Introduce `stock` router for listing and adding stock items
- Register new routers and add tests using in-memory SQLite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da96cfb34832ba27a18ff19010b2b