### PR TITLE
Initialize DB in startup event and update tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,9 +9,13 @@ app = FastAPI()
 app.add_middleware(SessionMiddleware, secret_key="super-secret-key")
 app.mount("/image", StaticFiles(directory="image"), name="image")
 
-# Initialize database and default admin user
-init_db()
-init_admin()
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize database tables and default admin user on startup."""
+    init_db()
+    init_admin()
+
 
 # Register API routes
 app.include_router(api_router)

--- a/tests/test_inventory_routes.py
+++ b/tests/test_inventory_routes.py
@@ -39,26 +39,26 @@ def setup_in_memory_db():
 def test_hardware_router_lists_added_items():
     setup_in_memory_db()
     app = create_app()
-    client = TestClient(app)
-    resp = client.post(
-        "/hardware/add",
-        data={"no": "001", "donanim_tipi": "Laptop"},
-        follow_redirects=False,
-    )
-    assert resp.status_code == 303
-    resp = client.get("/hardware")
-    assert resp.status_code == 200
-    assert "Laptop" in resp.text
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hardware/add",
+            data={"no": "001", "donanim_tipi": "Laptop"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        resp = client.get("/hardware")
+        assert resp.status_code == 200
+        assert "Laptop" in resp.text
 
 
 def test_stock_router_lists_added_items():
     setup_in_memory_db()
     app = create_app()
-    client = TestClient(app)
-    resp = client.post(
-        "/stock/add", data={"urun_adi": "Mouse", "adet": "5"}, follow_redirects=False
-    )
-    assert resp.status_code == 303
-    resp = client.get("/stock")
-    assert resp.status_code == 200
-    assert "Mouse" in resp.text
+    with TestClient(app) as client:
+        resp = client.post(
+            "/stock/add", data={"urun_adi": "Mouse", "adet": "5"}, follow_redirects=False
+        )
+        assert resp.status_code == 303
+        resp = client.get("/stock")
+        assert resp.status_code == 200
+        assert "Mouse" in resp.text


### PR DESCRIPTION
## Summary
- Initialize database and admin creation during FastAPI startup
- Trigger startup in tests by using `TestClient` as a context manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dab4bdeec832ba7e0f7278c2af99a