### PR TITLE
Allow logout via GET request

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -34,6 +34,7 @@ def login(request: Request, username: str = Form(...), password: str = Form(...)
     )
 
 
+@router.get("/logout")
 @router.post("/logout")
 def logout(request: Request):
     """Clear the current session."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,6 +59,23 @@ def test_login_creates_session_and_logout_clears_it():
         assert resp.status_code == 401
 
 
+def test_logout_via_get_request():
+    """Users should also be able to log out via GET requests."""
+    create_user()
+    with TestClient(main.app) as client:
+        client.post(
+            "/login", data={"username": "tester", "password": "secret"}, follow_redirects=False
+        )
+        resp = client.get("/ping")
+        assert resp.status_code == 200
+
+        resp = client.get("/logout", follow_redirects=False)
+        assert resp.status_code == 303
+
+        resp = client.get("/ping")
+        assert resp.status_code == 401
+
+
 def test_admin_routes_require_admin():
     create_user("admin_user", is_admin=True)
     create_user("normal_user", password="secret2", is_admin=False)


### PR DESCRIPTION
## Summary
- Support logging out through GET requests
- Test that logout works with GET method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc0e84db4832b85d3dc5d65dc4efd