### PR TITLE
Include inventory router for inventory forms

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -8,6 +8,7 @@ from .stock import router as stock_router
 from .reporting import router as reporting_router
 from .admin import router as admin_router
 from .inventory_pages import router as inventory_pages_router
+from .inventory import router as inventory_router
 
 router = APIRouter()
 router.include_router(auth_router)
@@ -16,5 +17,6 @@ router.include_router(stock_router, prefix="/stock")
 router.include_router(reporting_router)
 router.include_router(admin_router)
 router.include_router(inventory_pages_router)
+router.include_router(inventory_router)
 
 __all__ = ["router"]


### PR DESCRIPTION
## Summary
- import and register inventory router with the API router
- ensure templates' POST URLs (/inventory/add, /license/add, /printer/add) have corresponding routes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dc5151f98832bb6f587c174e873c0