### PR TITLE
Add trash page and restore operations

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -10,6 +10,7 @@ from .admin import router as admin_router
 from .inventory_pages import router as inventory_pages_router
 from .inventory import router as inventory_router
 from .connections import router as connections_router
+from .trash import router as trash_router
 
 router = APIRouter()
 router.include_router(auth_router)
@@ -20,5 +21,6 @@ router.include_router(admin_router)
 router.include_router(inventory_pages_router)
 router.include_router(inventory_router)
 router.include_router(connections_router)
+router.include_router(trash_router)
 
 __all__ = ["router"]

--- a/routes/trash.py
+++ b/routes/trash.py
@@ -1,0 +1,119 @@
+from datetime import date
+from typing import Dict, Tuple
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from models import (
+    SessionLocal,
+    DeletedHardwareInventory,
+    DeletedLicenseInventory,
+    DeletedPrinterInventory,
+    DeletedStockItem,
+    HardwareInventory,
+    LicenseInventory,
+    PrinterInventory,
+    StockItem,
+)
+from utils import templates
+from utils.auth import require_login
+
+router = APIRouter(dependencies=[Depends(require_login)])
+
+# Mapping for easier model lookup
+DELETED_MODELS: Dict[str, object] = {
+    "hardware": DeletedHardwareInventory,
+    "license": DeletedLicenseInventory,
+    "printer": DeletedPrinterInventory,
+    "stock": DeletedStockItem,
+}
+
+ACTIVE_MODELS: Dict[str, object] = {
+    "hardware": HardwareInventory,
+    "license": LicenseInventory,
+    "printer": PrinterInventory,
+    "stock": StockItem,
+}
+
+
+@router.get("/trash", response_class=HTMLResponse)
+def trash_page(request: Request) -> HTMLResponse:
+    """Render a page listing soft-deleted records."""
+    db = SessionLocal()
+    try:
+        hardware = db.query(DeletedHardwareInventory).all()
+        licenses = db.query(DeletedLicenseInventory).all()
+        printers = db.query(DeletedPrinterInventory).all()
+        stocks = db.query(DeletedStockItem).all()
+    finally:
+        db.close()
+
+    context = {
+        "request": request,
+        "hardware": hardware,
+        "licenses": licenses,
+        "printers": printers,
+        "stocks": stocks,
+        "today": date.today(),
+    }
+    return templates.TemplateResponse("trash.html", context)
+
+
+@router.post("/trash/delete")
+async def trash_delete(request: Request):
+    """Permanently delete selected items from the trash."""
+    form = await request.form()
+    item_type = form.get("item_type")
+    ids = [int(i) for i in form.getlist("ids")]
+    model = DELETED_MODELS.get(item_type)
+    db = SessionLocal()
+    try:
+        if model and ids:
+            db.query(model).filter(model.id.in_(ids)).delete(synchronize_session=False)
+            db.commit()
+    finally:
+        db.close()
+    return RedirectResponse("/trash", status_code=303)
+
+
+def _restore_item(item_id: int, models_pair: Tuple[object, object]) -> None:
+    deleted_model, active_model = models_pair
+    db = SessionLocal()
+    try:
+        item = db.query(deleted_model).get(item_id)
+        if item:
+            data = {
+                col.name: getattr(item, col.name, None)
+                for col in active_model.__table__.columns
+                if col.name != "id"
+            }
+            restored = active_model(**data)
+            db.add(restored)
+            db.delete(item)
+            db.commit()
+    finally:
+        db.close()
+
+
+@router.post("/inventory/restore/{item_id}")
+def restore_hardware(item_id: int):
+    _restore_item(item_id, (DeletedHardwareInventory, HardwareInventory))
+    return RedirectResponse("/trash", status_code=303)
+
+
+@router.post("/license/restore/{item_id}")
+def restore_license(item_id: int):
+    _restore_item(item_id, (DeletedLicenseInventory, LicenseInventory))
+    return RedirectResponse("/trash", status_code=303)
+
+
+@router.post("/printer/restore/{item_id}")
+def restore_printer(item_id: int):
+    _restore_item(item_id, (DeletedPrinterInventory, PrinterInventory))
+    return RedirectResponse("/trash", status_code=303)
+
+
+@router.post("/stock/restore/{item_id}")
+def restore_stock(item_id: int):
+    _restore_item(item_id, (DeletedStockItem, StockItem))
+    return RedirectResponse("/trash", status_code=303)

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,6 +55,7 @@
         <li class="nav-item mt-3"><span class="nav-link text-white text-uppercase fw-bold disabled">İşlemler</span></li>
         <li><a href="/requests" class="nav-link text-white {% if request.path.startswith('/requests') %}active{% endif %}">Talep Takip</a></li>
         <li><a href="/stock" class="nav-link text-white {% if request.path.startswith('/stock') %}active{% endif %}">Stok Takip</a></li>
+        <li><a href="/trash" class="nav-link text-white {% if request.path.startswith('/trash') %}active{% endif %}">Çöp Kutusu</a></li>
 
         <li class="nav-item mt-3"><span class="nav-link text-white text-uppercase fw-bold disabled">Ayarlar</span></li>
         <li><a href="/profile" class="nav-link text-white {% if request.path.startswith('/profile') %}active{% endif %}">Profil</a></li>

--- a/tests/test_trash_page.py
+++ b/tests/test_trash_page.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Reuse the helper and DB setup from test_app
+sys.path.append(os.path.dirname(__file__))
+from test_app import create_user  # noqa: E402
+
+from fastapi.testclient import TestClient
+import main  # noqa: E402
+
+
+def test_trash_page_accessible_after_login():
+    create_user()
+    with TestClient(main.app) as client:
+        client.post(
+            "/login",
+            data={"username": "tester", "password": "secret"},
+            follow_redirects=False,
+        )
+        resp = client.get("/trash")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Implement `/trash` page displaying soft-deleted hardware, licenses, printers, and stock
- Allow permanent deletion and restoration of items from trash
- Add navigation link and tests for new trash page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dc96d0aa0832bbd404c30c5aa1777