### PR TITLE
Remove ID column and add scrollable tables

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
   <style>
     *{ box-sizing: border-box; }
     body{ margin:0; font-family: Arial, sans-serif; color:#111; overflow-x:auto; }
-    .table-container{ width:max-content; min-width:100%; }
+    .table-container{ width:max-content; min-width:100%; overflow:auto; }
     .table-fixed{ table-layout:auto; width:max-content; min-width:100%; }
     .table-fixed td{ white-space:normal; word-break:break-word; }
     .table-resizable th,
@@ -113,6 +113,14 @@
       });
     }
     document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('table').forEach(tbl => {
+        if (!tbl.parentElement.classList.contains('table-container')) {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'table-container';
+          tbl.parentNode.insertBefore(wrapper, tbl);
+          wrapper.appendChild(tbl);
+        }
+      });
       document.querySelectorAll('table.table-resizable').forEach(makeTableResizable);
       const searchForm = document.getElementById('search-form');
       const filtersContainer = document.getElementById('filters-container');

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -44,7 +44,9 @@ def save_settings(data: dict) -> None:
 
 def get_table_columns(table_name: str) -> List[str]:
     """Return a list of column names for the given table."""
-    return [col["name"] for col in inspect(engine).get_columns(table_name)]
+    columns = [col["name"] for col in inspect(engine).get_columns(table_name)]
+    # Skip primary key identifiers which are not meant for display/editing
+    return [c for c in columns if c != "id"]
 
 
 def cleanup_deleted(db: Session) -> None:


### PR DESCRIPTION
## Summary
- hide ID field from table column listings
- wrap tables with a scrollable container on all pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dcfb78ab4832b8f6ccdc8adee122d