### PR TITLE
Enable horizontal scrolling in inventory table

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -17,7 +17,8 @@ html, body { height: 100%; margin: 0; overflow: hidden; }
 .table-scroll {
   flex: 1 1 auto;
   height: calc(100vh - 100px);
-  overflow: auto;                /* hem yatay hem dikey scroll */
+  overflow-x: auto;
+  overflow-y: auto;              /* hem yatay hem dikey scroll */
   border: 1px solid #eee;
   border-radius: 6px;
   background: #fff;
@@ -25,7 +26,6 @@ html, body { height: 100%; margin: 0; overflow: hidden; }
 
 /* Tablo ekrana sığsın; gerekirse yatay scroll açılsın */
 .table-scroll table {
-  width: 100%;
   table-layout: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow inventory table container to scroll horizontally
- remove width override so table can extend past viewport

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ddefc7db4832baeffb153ea3b64b1