### PR TITLE
Remove inventory prefix and expose stock list route

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -19,7 +19,7 @@ router.include_router(stock_router, prefix="/stock")
 router.include_router(reporting_router)
 router.include_router(admin_router)
 router.include_router(inventory_pages_router)
-router.include_router(inventory_router, prefix="/inventory-api")
+router.include_router(inventory_router)
 router.include_router(connections_router)
 router.include_router(trash_router)
 

--- a/routes/inventory.py
+++ b/routes/inventory.py
@@ -6,7 +6,7 @@ import csv
 from io import StringIO
 
 from fastapi import APIRouter, Depends, File, Request, UploadFile
-from fastapi.responses import RedirectResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 
 from utils.auth import require_login
 from models import (
@@ -22,6 +22,7 @@ from models import (
     DeletedStockItem,
 )
 from utils import get_table_columns, load_settings, save_settings, log_action
+from .stock import list_stock as stock_list
 
 
 router = APIRouter(dependencies=[Depends(require_login)])
@@ -145,6 +146,12 @@ async def stock_add(request: Request):
     finally:
         db.close()
     return RedirectResponse("/stock", status_code=303)
+
+
+@router.get("/stock", response_class=HTMLResponse)
+def stock_list_page(request: Request) -> HTMLResponse:
+    """Render the stock list page."""
+    return stock_list(request)
 
 
 @router.post("/printer/add")


### PR DESCRIPTION
## Summary
- Remove `/inventory-api` prefix when including the inventory router so template actions continue working
- Expose a `/stock` listing endpoint inside the inventory router by reusing the stock module handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df2f99634832baa8bf343b9bc0c16