### PR TITLE
Make sidebar sticky

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,8 +42,8 @@
   </style>
 </head>
 <body>
-  <div class="d-flex" style="height:100vh; width:100%;">
-    <nav class="sidebar flex-shrink-0 p-3 text-white bg-dark" style="width:200px;">
+  <div class="d-flex" style="height:100vh; width:100%; overflow-y:auto;">
+    <nav class="sidebar flex-shrink-0 p-3 text-white bg-dark" style="width:200px; position: sticky; top: 0; height: 100vh;">
       <img src="/image/onurum.png" alt="Onurum" class="img-fluid mb-3" style="width:150px">
       <ul class="nav nav-pills flex-column mb-auto">
         <li class="nav-item"><a href="/home" class="nav-link text-white {% if request.path.startswith('/home') %}active{% endif %}">Ana Sayfa</a></li>


### PR DESCRIPTION
## Summary
- Keep sidebar visible during scrolling by making it sticky and full height
- Allow page scrolling while sidebar remains fixed

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e43119114832b9a70b40475648341