### PR TITLE
Read session secret from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 ## Environment Variables
 
-The application initializes an administrator account using credentials supplied via environment variables.
+The application initializes an administrator account using credentials supplied via environment variables and requires a secret key for session handling.
 
 - `ADMIN_USERNAME` – Username for the initial administrator.
 - `ADMIN_PASSWORD` – Password for the initial administrator.
+- `SESSION_SECRET` – Secret key used to sign session cookies.
 
-Both variables must be defined before the application starts. If either variable is missing, the application will exit with an error instead of creating the admin user.
+All three variables must be defined before the application starts. If any variable is missing, the application will exit with an error instead of creating the admin user or starting the server.
 
 When using Docker Compose, provide these variables in your environment or an `.env` file:
 
 ```
 ADMIN_USERNAME=your_admin_username
 ADMIN_PASSWORD=your_admin_password
+SESSION_SECRET=some_long_random_string
 ```
 
 ## Authentication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
       - ADMIN_USERNAME
       - ADMIN_PASSWORD
+      - SESSION_SECRET
     volumes:
       - ./data:/app/data
       - ./image:/app/image     # hosttaki image klasörünü container’a bağla

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
@@ -7,7 +9,12 @@ from routes import router as api_router
 from utils import cleanup_deleted
 
 app = FastAPI()
-app.add_middleware(SessionMiddleware, secret_key="super-secret-key")
+
+secret_key = os.getenv("SESSION_SECRET")
+if not secret_key:
+    raise RuntimeError("SESSION_SECRET environment variable is not set")
+
+app.add_middleware(SessionMiddleware, secret_key=secret_key)
 app.mount("/image", StaticFiles(directory="image"), name="image")
 app.mount("/static", StaticFiles(directory="static"), name="static")
 


### PR DESCRIPTION
## Summary
- Load session secret key from `SESSION_SECRET` environment variable and fail fast if unset
- Document required `SESSION_SECRET` variable and add it to Docker Compose configuration

## Testing
- `SESSION_SECRET=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed601ff44832b87f423b075e6e09f