### PR TITLE
Fix column settings persistence for license and printer pages

### DIFF
--- a/routes/inventory_pages.py
+++ b/routes/inventory_pages.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from fastapi import APIRouter, Depends, Request, Form
+from fastapi import APIRouter, Depends, Request, Form, Body
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from sqlalchemy import or_, String
 import math
@@ -493,7 +493,9 @@ def column_settings(request: Request, table_name: str):
 
 
 @router.post("/column-settings")
-def save_column_settings(request: Request, table_name: str, data: dict):
+def save_column_settings(
+    request: Request, table_name: str, data: dict = Body(...)
+):
     """Persist column settings for a table."""
     settings = load_settings()
     settings[table_name] = data

--- a/tests/test_column_settings.py
+++ b/tests/test_column_settings.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import models
+import utils
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from starlette.middleware.sessions import SessionMiddleware
+
+from routes.inventory_pages import router as inventory_pages_router
+from utils.auth import require_login
+
+
+def create_app():
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test")
+    app.include_router(inventory_pages_router)
+    app.dependency_overrides[require_login] = lambda: None
+    return app
+
+
+def setup_in_memory_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.engine = engine
+    models.SessionLocal = TestingSessionLocal
+    models.Base.metadata.create_all(bind=engine)
+
+
+def test_save_and_load_column_settings(tmp_path):
+    setup_in_memory_db()
+    utils.SETTINGS_FILE = str(tmp_path / "settings.json")
+    app = create_app()
+    data_license = {"order": ["a"], "visible": ["a"], "widths": {"a": 100}}
+    data_printer = {"order": ["b"], "visible": ["b"], "widths": {"b": 80}}
+    with TestClient(app) as client:
+        resp = client.post(
+            "/column-settings?table_name=license", json=data_license
+        )
+        assert resp.status_code == 200
+        resp = client.get("/column-settings?table_name=license")
+        assert resp.json() == data_license
+        resp = client.post(
+            "/column-settings?table_name=printer", json=data_printer
+        )
+        assert resp.status_code == 200
+        resp = client.get("/column-settings?table_name=printer")
+        assert resp.json() == data_printer


### PR DESCRIPTION
## Summary
- ensure `/column-settings` endpoint accepts JSON bodies and saves settings
- add regression test covering license and printer column settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee2c16ecc832bbcc626bb06526c9b