### PR TITLE
Prefill forms from inventory and auto-set current date

### DIFF
--- a/routes/inventory.py
+++ b/routes/inventory.py
@@ -6,7 +6,7 @@ import csv
 from io import StringIO
 
 from fastapi import APIRouter, Depends, File, Request, UploadFile
-from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse, JSONResponse
 
 from utils.auth import require_login
 from models import (
@@ -38,6 +38,24 @@ MODEL_MAP = {
     "inventory": HardwareInventory,
     "accessory": AccessoryInventory,
 }
+
+
+@router.get("/inventory/fetch/{no}")
+def inventory_fetch(no: str):
+    """Fetch hardware inventory details by inventory number."""
+    db = SessionLocal()
+    try:
+        item = db.query(HardwareInventory).filter(HardwareInventory.no == no).first()
+        if not item:
+            return JSONResponse({"status": "not_found"}, status_code=404)
+        return {
+            "departman": item.departman,
+            "sorumlu_personel": item.sorumlu_personel,
+            "kullanim_alani": item.kullanim_alani,
+            "bilgisayar_adi": item.bilgisayar_adi,
+        }
+    finally:
+        db.close()
 
 
 def _export_model(model, filename: str) -> StreamingResponse:

--- a/routes/inventory_pages.py
+++ b/routes/inventory_pages.py
@@ -87,6 +87,7 @@ def inventory_page(request: Request) -> HTMLResponse:
         "count": total_count,
         "filter_field": filter_field,
         "filter_value": filter_value,
+        "today": date.today().isoformat(),
     }
     return templates.TemplateResponse("envanter.html", context)
 
@@ -144,6 +145,7 @@ def printer_page(request: Request) -> HTMLResponse:
         "count": total_count,
         "filter_field": filter_field,
         "filter_value": filter_value,
+        "today": date.today().isoformat(),
     }
     return templates.TemplateResponse("yazici.html", context)
 
@@ -201,6 +203,7 @@ def license_page(request: Request) -> HTMLResponse:
         "count": total_count,
         "filter_field": filter_field,
         "filter_value": filter_value,
+        "today": date.today().isoformat(),
     }
     return templates.TemplateResponse("lisans.html", context)
 
@@ -258,6 +261,7 @@ def accessories_page(request: Request) -> HTMLResponse:
         "count": total_count,
         "filter_field": filter_field,
         "filter_value": filter_value,
+        "today": date.today().isoformat(),
     }
     return templates.TemplateResponse("aksesuar.html", context)
 

--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -93,7 +93,7 @@
               {% if col == 'aciklama' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -125,6 +125,10 @@
       </div>
       <form id="addForm" action="/accessories/add" method="post">
           <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label">Envanter No</label>
+              <input type="text" class="form-control" id="envanter_no_lookup">
+            </div>
             {% for col in columns %}
             {% if col != 'islem_yapan' %}
             <div class="mb-3">
@@ -132,7 +136,7 @@
               {% if col == 'aciklama' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -321,6 +325,20 @@ if (perPageSelect) {
         document.getElementById('search-form').submit();
     });
 }
+
+const accEnvInput = document.getElementById('envanter_no_lookup');
+accEnvInput?.addEventListener('change', async () => {
+    const val = accEnvInput.value.trim();
+    if (!val) return;
+    const res = await fetch(`/inventory/fetch/${val}`);
+    if (res.ok) {
+        const data = await res.json();
+        const dept = document.querySelector('#addForm input[name="departman"]');
+        const user = document.querySelector('#addForm input[name="kullanici"]');
+        if (data.departman && dept) dept.value = data.departman;
+        if (data.sorumlu_personel && user) user.value = data.sorumlu_personel;
+    }
+});
 </script>
 {% endblock %}
 

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -110,7 +110,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -148,7 +148,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -98,7 +98,7 @@
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -137,7 +137,7 @@
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -359,5 +359,19 @@ if (perPageSelect) {
         document.getElementById('search-form').submit();
     });
 }
+
+const licenseEnvInput = document.querySelector('#addForm input[name="envanter_no"]');
+licenseEnvInput?.addEventListener('change', async () => {
+    const val = licenseEnvInput.value.trim();
+    if (!val) return;
+    const res = await fetch(`/inventory/fetch/${val}`);
+    if (res.ok) {
+        const data = await res.json();
+        const dept = document.querySelector('#addForm input[name="departman"]');
+        const user = document.querySelector('#addForm input[name="kullanici"]');
+        if (data.departman && dept) dept.value = data.departman;
+        if (data.sorumlu_personel && user) user.value = data.sorumlu_personel;
+    }
+});
 </script>
 {% endblock %}

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -102,7 +102,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -127,6 +127,10 @@
       </div>
       <form id="addForm" action="/printer/add" method="post">
           <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label">Envanter No</label>
+              <input type="text" class="form-control" id="envanter_no_lookup">
+            </div>
             {% for col in columns %}
             {% if col != 'islem_yapan' %}
             <div class="mb-3">
@@ -139,7 +143,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" required>
+              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -353,5 +357,19 @@ if (perPageSelect) {
         document.getElementById('search-form').submit();
     });
 }
+
+const printerEnvInput = document.getElementById('envanter_no_lookup');
+printerEnvInput?.addEventListener('change', async () => {
+    const val = printerEnvInput.value.trim();
+    if (!val) return;
+    const res = await fetch(`/inventory/fetch/${val}`);
+    if (res.ok) {
+        const data = await res.json();
+        const area = document.querySelector('#addForm input[name="kullanim_alani"]');
+        const host = document.querySelector('#addForm input[name="hostname"]');
+        if (data.kullanim_alani && area) area.value = data.kullanim_alani;
+        if (data.bilgisayar_adi && host) host.value = data.bilgisayar_adi;
+    }
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- supply today's date to inventory, printer, license and accessory forms
- fetch hardware details for license, accessory and printer forms via new /inventory/fetch/{no} endpoint
- auto-fill department, user or location fields from existing hardware inventory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee4d8c888832b89208fe4d2ca1b5f