### PR TITLE
Remove IFS input and auto-date inventory records

### DIFF
--- a/routes/inventory.py
+++ b/routes/inventory.py
@@ -189,14 +189,10 @@ async def printer_add(request: Request):
                     "ip_adresi",
                     "mac",
                     "hostname",
-                    "tarih",
                     "notlar",
                 ]:
                     if field in form:
-                        value = form.get(field)
-                        if field == "tarih":
-                            value = date.fromisoformat(value) if value else None
-                        setattr(item, field, value)
+                        setattr(item, field, form.get(field))
                 item.islem_yapan = request.session.get("full_name", "")
             action = f"Updated printer item {printer_id}"
         else:
@@ -207,10 +203,7 @@ async def printer_add(request: Request):
                 ip_adresi=form.get("ip_adresi"),
                 mac=form.get("mac"),
                 hostname=form.get("hostname"),
-                tarih=
-                    date.fromisoformat(form.get("tarih"))
-                    if form.get("tarih")
-                    else None,
+                tarih=date.today(),
                 islem_yapan=request.session.get("full_name", ""),
                 notlar=form.get("notlar"),
             )
@@ -253,14 +246,9 @@ async def inventory_add(request: Request):
                     "sorumlu_personel",
                     "kullanim_alani",
                     "bagli_makina_no",
-                    "ifs_no",
-                    "tarih",
                 ]:
                     if field in form:
-                        value = form.get(field)
-                        if field == "tarih":
-                            value = date.fromisoformat(value) if value else None
-                        setattr(item, field, value)
+                        setattr(item, field, form.get(field))
                 item.islem_yapan = request.session.get("full_name", "")
             action = f"Updated hardware item {item_id}"
         else:
@@ -277,11 +265,7 @@ async def inventory_add(request: Request):
                 sorumlu_personel=form.get("sorumlu_personel"),
                 kullanim_alani=form.get("kullanim_alani"),
                 bagli_makina_no=form.get("bagli_makina_no"),
-                ifs_no=form.get("ifs_no"),
-                tarih=
-                    date.fromisoformat(form.get("tarih"))
-                    if form.get("tarih")
-                    else None,
+                tarih=date.today(),
                 islem_yapan=request.session.get("full_name", ""),
             )
             db.add(item)
@@ -317,15 +301,10 @@ async def license_add(request: Request):
                     "lisans_anahtari",
                     "mail_adresi",
                     "envanter_no",
-                    "ifs_no",
-                    "tarih",
                     "notlar",
                 ]:
                     if field in form:
-                        value = form.get(field)
-                        if field == "tarih":
-                            value = date.fromisoformat(value) if value else None
-                        setattr(item, field, value)
+                        setattr(item, field, form.get(field))
                 item.islem_yapan = request.session.get("full_name", "")
             action = f"Updated license item {license_id}"
         else:
@@ -336,11 +315,7 @@ async def license_add(request: Request):
                 lisans_anahtari=form.get("lisans_anahtari"),
                 mail_adresi=form.get("mail_adresi"),
                 envanter_no=form.get("envanter_no"),
-                ifs_no=form.get("ifs_no"),
-                tarih=
-                    date.fromisoformat(form.get("tarih"))
-                    if form.get("tarih")
-                    else None,
+                tarih=date.today(),
                 islem_yapan=request.session.get("full_name", ""),
                 notlar=form.get("notlar"),
             )
@@ -373,8 +348,6 @@ async def accessories_add(request: Request):
                 for field in [
                     "urun_adi",
                     "adet",
-                    "tarih",
-                    "ifs_no",
                     "departman",
                     "kullanici",
                     "aciklama",
@@ -383,8 +356,6 @@ async def accessories_add(request: Request):
                         value = form.get(field)
                         if field == "adet":
                             value = int(value) if value else None
-                        elif field == "tarih":
-                            value = date.fromisoformat(value) if value else None
                         setattr(item, field, value)
                 item.islem_yapan = request.session.get("full_name", "")
             action = f"Updated accessory item {accessory_id}"
@@ -392,11 +363,7 @@ async def accessories_add(request: Request):
             item = AccessoryInventory(
                 urun_adi=form.get("urun_adi"),
                 adet=int(form.get("adet") or 0),
-                tarih=
-                    date.fromisoformat(form.get("tarih"))
-                    if form.get("tarih")
-                    else None,
-                ifs_no=form.get("ifs_no"),
+                tarih=date.today(),
                 departman=form.get("departman"),
                 kullanici=form.get("kullanici"),
                 aciklama=form.get("aciklama"),

--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -87,13 +87,13 @@
         <input type="hidden" name="accessory_id">
           <div class="modal-body">
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if col == 'aciklama' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -130,13 +130,13 @@
               <input type="text" class="form-control" id="envanter_no_lookup">
             </div>
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if col == 'aciklama' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -99,7 +99,7 @@
           <div class="modal-body">
             <div class="row row-cols-1 row-cols-md-3 g-3">
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="col">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
@@ -110,7 +110,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -137,7 +137,7 @@
           <div class="modal-body">
             <div class="row row-cols-1 row-cols-md-3 g-3">
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="col">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
@@ -148,7 +148,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -92,13 +92,13 @@
         <input type="hidden" name="license_id">
           <div class="modal-body">
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
@@ -131,13 +131,13 @@
       <form id="addForm" action="/license/add" method="post">
           <div class="modal-body">
             {% for col in columns %}
-            {% if col != 'islem_yapan' %}
+            {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="mb-3">
               <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
               {% if col == 'notlar' %}
               <textarea class="form-control" name="{{ col }}" required></textarea>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% elif lookups.get(col) %}
               <select class="form-select" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -102,7 +102,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}
@@ -143,7 +143,7 @@
                 {% endfor %}
               </select>
               {% elif col == 'tarih' %}
-              <input type="date" class="form-control" name="{{ col }}" value="{{ today }}" required>
+              <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
               <input type="text" class="form-control" name="{{ col }}" required>
               {% endif %}


### PR DESCRIPTION
## Summary
- Stop updating `tarih` and ignore `ifs_no` in printer, hardware, license and accessory routes
- Hide IFS number fields and use hidden current date in inventory, license, accessory and printer templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eecf9e03c832bb2f42212f0dc7856