### PR TITLE
Display add-form fields in three columns

### DIFF
--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -125,31 +125,33 @@
       </div>
       <form id="addForm" action="/accessories/add" method="post">
           <div class="modal-body">
-            <div class="mb-3">
-              <label class="form-label">Envanter No</label>
-              <input type="text" class="form-control" id="envanter_no_lookup">
-            </div>
-            {% for col in columns %}
-            {% if col not in ['islem_yapan', 'ifs_no'] %}
-            <div class="mb-3">
-              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
-              {% if col == 'aciklama' %}
-              <textarea class="form-control" name="{{ col }}" required></textarea>
-              {% elif col == 'tarih' %}
-              <input type="hidden" name="{{ col }}" value="{{ today }}">
-              {% elif lookups.get(col) %}
-              <select class="form-select" name="{{ col }}" required>
-                <option value="" disabled selected>Seçiniz</option>
-                {% for val in lookups.get(col) %}
-                <option value="{{ val }}">{{ val }}</option>
-                {% endfor %}
-              </select>
-              {% else %}
-              <input type="text" class="form-control" name="{{ col }}" required>
+            <div class="row g-3">
+              <div class="col-md-4 mb-3">
+                <label class="form-label">Envanter No</label>
+                <input type="text" class="form-control" id="envanter_no_lookup">
+              </div>
+              {% for col in columns %}
+              {% if col not in ['islem_yapan', 'ifs_no'] %}
+              <div class="col-md-4 mb-3">
+                <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+                {% if col == 'aciklama' %}
+                <textarea class="form-control" name="{{ col }}" required></textarea>
+                {% elif col == 'tarih' %}
+                <input type="hidden" name="{{ col }}" value="{{ today }}">
+                {% elif lookups.get(col) %}
+                <select class="form-select" name="{{ col }}" required>
+                  <option value="" disabled selected>Seçiniz</option>
+                  {% for val in lookups.get(col) %}
+                  <option value="{{ val }}">{{ val }}</option>
+                  {% endfor %}
+                </select>
+                {% else %}
+                <input type="text" class="form-control" name="{{ col }}" required>
+                {% endif %}
+              </div>
               {% endif %}
+              {% endfor %}
             </div>
-            {% endif %}
-            {% endfor %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -130,27 +130,29 @@
       </div>
       <form id="addForm" action="/license/add" method="post">
           <div class="modal-body">
-            {% for col in columns %}
-            {% if col not in ['islem_yapan', 'ifs_no'] %}
-            <div class="mb-3">
-              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
-              {% if col == 'notlar' %}
-              <textarea class="form-control" name="{{ col }}" required></textarea>
-              {% elif col == 'tarih' %}
-              <input type="hidden" name="{{ col }}" value="{{ today }}">
-              {% elif lookups.get(col) %}
-              <select class="form-select" name="{{ col }}" required>
-                <option value="" disabled selected>Seçiniz</option>
-                {% for val in lookups.get(col) %}
-                <option value="{{ val }}">{{ val }}</option>
-                {% endfor %}
-              </select>
-              {% else %}
-              <input type="text" class="form-control" name="{{ col }}" required>
+            <div class="row g-3">
+              {% for col in columns %}
+              {% if col not in ['islem_yapan', 'ifs_no'] %}
+              <div class="col-md-4 mb-3">
+                <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+                {% if col == 'notlar' %}
+                <textarea class="form-control" name="{{ col }}" required></textarea>
+                {% elif col == 'tarih' %}
+                <input type="hidden" name="{{ col }}" value="{{ today }}">
+                {% elif lookups.get(col) %}
+                <select class="form-select" name="{{ col }}" required>
+                  <option value="" disabled selected>Seçiniz</option>
+                  {% for val in lookups.get(col) %}
+                  <option value="{{ val }}">{{ val }}</option>
+                  {% endfor %}
+                </select>
+                {% else %}
+                <input type="text" class="form-control" name="{{ col }}" required>
+                {% endif %}
+              </div>
               {% endif %}
+              {% endfor %}
             </div>
-            {% endif %}
-            {% endfor %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -136,31 +136,33 @@
       </div>
       <form id="addForm" action="/stock/add" method="post">
         <div class="modal-body">
-          {% for col in columns %}
-          {% if col != 'islem_yapan' %}
-          <div class="mb-3">
-            <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
-            {% if col == 'aciklama' %}
-            <textarea class="form-control" name="{{ col }}" required></textarea>
-            {% elif col == 'tarih' %}
-            <input type="date" class="form-control" name="{{ col }}" required>
-            {% elif col == 'adet' %}
-            <input type="number" class="form-control" name="{{ col }}" min="0" required>
-            {% else %}
-            {% if lookups.get(col) %}
-            <select class="form-select" name="{{ col }}" required>
-              <option value="" disabled selected>Seçiniz</option>
-              {% for val in lookups.get(col) %}
-              <option value="{{ val }}">{{ val }}</option>
-              {% endfor %}
-            </select>
-            {% else %}
-            <input type="text" class="form-control" name="{{ col }}" required>
+          <div class="row g-3">
+            {% for col in columns %}
+            {% if col != 'islem_yapan' %}
+            <div class="col-md-4 mb-3">
+              <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
+              {% if col == 'aciklama' %}
+              <textarea class="form-control" name="{{ col }}" required></textarea>
+              {% elif col == 'tarih' %}
+              <input type="date" class="form-control" name="{{ col }}" required>
+              {% elif col == 'adet' %}
+              <input type="number" class="form-control" name="{{ col }}" min="0" required>
+              {% else %}
+              {% if lookups.get(col) %}
+              <select class="form-select" name="{{ col }}" required>
+                <option value="" disabled selected>Seçiniz</option>
+                {% for val in lookups.get(col) %}
+                <option value="{{ val }}">{{ val }}</option>
+                {% endfor %}
+              </select>
+              {% else %}
+              <input type="text" class="form-control" name="{{ col }}" required>
+              {% endif %}
+              {% endif %}
+            </div>
             {% endif %}
-            {% endif %}
+            {% endfor %}
           </div>
-          {% endif %}
-          {% endfor %}
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -127,29 +127,31 @@
       </div>
       <form id="addForm" action="/printer/add" method="post">
           <div class="modal-body">
-            <div class="mb-3">
-              <label class="form-label">Envanter No</label>
-              <input type="text" class="form-control" id="envanter_no_lookup">
-            </div>
-            {% for col in columns %}
-            {% if col != 'islem_yapan' %}
-            <div class="mb-3">
-              <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
-              {% if lookups.get(col) %}
-              <select class="form-select" name="{{ col }}" required>
-                <option value="" disabled selected>Seçiniz</option>
-                {% for val in lookups.get(col) %}
-                <option value="{{ val }}">{{ val }}</option>
-                {% endfor %}
-              </select>
-              {% elif col == 'tarih' %}
-              <input type="hidden" name="{{ col }}" value="{{ today }}">
-              {% else %}
-              <input type="text" class="form-control" name="{{ col }}" required>
+            <div class="row g-3">
+              <div class="col-md-4 mb-3">
+                <label class="form-label">Envanter No</label>
+                <input type="text" class="form-control" id="envanter_no_lookup">
+              </div>
+              {% for col in columns %}
+              {% if col != 'islem_yapan' %}
+              <div class="col-md-4 mb-3">
+                <label class="form-label">{{ col.replace('_', ' ').title() }}</label>
+                {% if lookups.get(col) %}
+                <select class="form-select" name="{{ col }}" required>
+                  <option value="" disabled selected>Seçiniz</option>
+                  {% for val in lookups.get(col) %}
+                  <option value="{{ val }}">{{ val }}</option>
+                  {% endfor %}
+                </select>
+                {% elif col == 'tarih' %}
+                <input type="hidden" name="{{ col }}" value="{{ today }}">
+                {% else %}
+                <input type="text" class="form-control" name="{{ col }}" required>
+                {% endif %}
+              </div>
               {% endif %}
+              {% endfor %}
             </div>
-            {% endif %}
-            {% endfor %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>


### PR DESCRIPTION
## Summary
- show license, accessory, printer, and stock add forms in three-column rows for clearer input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ef07f04a4832b9434718ff494ff20