### PR TITLE
Reduce size of form elements on profile, connections and inventory pages

### DIFF
--- a/templates/connections.html
+++ b/templates/connections.html
@@ -7,23 +7,23 @@
 <form method="post" action="/connections">
   <div class="mb-3">
     <label class="form-label">Sunucu</label>
-    <input type="text" name="server" class="form-control" required>
+    <input type="text" name="server" class="form-control form-control-sm" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Port</label>
-    <input type="number" name="port" class="form-control" value="389">
+    <input type="number" name="port" class="form-control form-control-sm" value="389">
   </div>
   <div class="mb-3">
     <label class="form-label">Kullanıcı DN</label>
-    <input type="text" name="user_dn" class="form-control" required>
+    <input type="text" name="user_dn" class="form-control form-control-sm" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Şifre</label>
-    <input type="password" name="password" class="form-control" required>
+    <input type="password" name="password" class="form-control form-control-sm" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Base DN</label>
-    <input type="text" name="base_dn" class="form-control" required>
+    <input type="text" name="base_dn" class="form-control form-control-sm" required>
   </div>
   <button type="submit" class="btn btn-primary">Kullanıcıları Çek</button>
 </form>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -59,7 +59,7 @@
         <i class="bi bi-x"></i>
       </button>
     </div>
-    <select id="per-page" name="per_page" class="form-select" style="max-width: 100px;">
+    <select id="per-page" name="per_page" class="form-select form-select-sm" style="max-width: 100px;">
       {% for opt in [25,50,100] %}
       <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
       {% endfor %}
@@ -68,7 +68,7 @@
 </div>
 
 <form id="uploadForm" action="/inventory/upload" method="post" enctype="multipart/form-data" style="display:none;">
-    <input id="excelInput" type="file" class="form-control" name="excel_file" accept=".xls,.xlsx" required>
+    <input id="excelInput" type="file" class="form-control form-control-sm" name="excel_file" accept=".xls,.xlsx" required>
 </form>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
@@ -103,7 +103,7 @@
             <div class="col">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
-              <select class="form-select" name="{{ col }}" required>
+              <select class="form-select form-select-sm" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
                 <option value="{{ val }}">{{ val }}</option>
@@ -112,7 +112,7 @@
               {% elif col == 'tarih' %}
               <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
-              <input type="text" class="form-control" name="{{ col }}" required>
+              <input type="text" class="form-control form-control-sm" name="{{ col }}" required>
               {% endif %}
             </div>
             {% endif %}
@@ -141,7 +141,7 @@
             <div class="col">
               <label class="form-label">{{ column_labels.get(col, col.replace('_', ' ').title()) }}</label>
               {% if lookups.get(col) %}
-              <select class="form-select" name="{{ col }}" required>
+              <select class="form-select form-select-sm" name="{{ col }}" required>
                 <option value="" disabled selected>Seçiniz</option>
                 {% for val in lookups.get(col) %}
                 <option value="{{ val }}">{{ val }}</option>
@@ -150,7 +150,7 @@
               {% elif col == 'tarih' %}
               <input type="hidden" name="{{ col }}" value="{{ today }}">
               {% else %}
-              <input type="text" class="form-control" name="{{ col }}" required>
+              <input type="text" class="form-control form-control-sm" name="{{ col }}" required>
               {% endif %}
             </div>
             {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -5,5 +5,5 @@
 <div class="mb-2"><strong>İsim:</strong> {{ user.first_name }}</div>
 <div class="mb-2"><strong>Soyisim:</strong> {{ user.last_name }}</div>
 <div class="mb-2"><strong>Mail:</strong> {{ user.email }}</div>
-<a href="/change-password" class="btn btn-primary mt-3">Şifre Değiştir</a>
+<a href="/change-password" class="btn btn-primary btn-sm mt-3">Şifre Değiştir</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Use smaller button for "Şifre Değiştir" on profile page
- Shrink input fields on connections page with `form-control-sm`
- Apply `form-control-sm`/`form-select-sm` for inventory add/edit modals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef21bd204832bb3460592a14fa763