### PR TITLE
Adjust inventory form layout to four-column grid

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -97,7 +97,7 @@
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
           <div class="modal-body">
-            <div class="row row-cols-1 row-cols-md-3 g-3">
+            <div class="row row-cols-1 row-cols-md-4 g-3">
             {% for col in columns %}
             {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="col">
@@ -135,7 +135,7 @@
       </div>
       <form id="addForm" action="/inventory/add" method="post">
           <div class="modal-body">
-            <div class="row row-cols-1 row-cols-md-3 g-3">
+            <div class="row row-cols-1 row-cols-md-4 g-3">
             {% for col in columns %}
             {% if col not in ['islem_yapan', 'ifs_no'] %}
             <div class="col">


### PR DESCRIPTION
## Summary
- show inventory edit/add form fields in four-column grid for clearer input layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef8a0a5b0832b9c25b009f42a0051