### PR TITLE
Style inventory rows with fixed height

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -72,3 +72,11 @@ html, body {
 .w-200 {
   width: 200px !important;
 }
+
+.inventory-rows .list-group-item {
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+}

--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -2,7 +2,7 @@
 {% block title %}Envanter Ekleme{% endblock %}
 {% block content %}
 <h2>Envanter Ekleme</h2>
-<div class="list-group">
+<div class="list-group inventory-rows">
   <div class="list-group-item d-flex justify-content-between align-items-center">
     <span>Marka</span>
     <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#markaModal"><i class="bi bi-list"></i></button>


### PR DESCRIPTION
## Summary
- Add `inventory-rows` class to main list on Envanter Ekleme page
- Define styling to make each inventory row 200px tall and aligned

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689efb7ab748832b9e8a0dc7284db7be