### PR TITLE
Set fixed width for inventory page modals

### DIFF
--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -72,7 +72,7 @@
 </form>
 
 <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog w-200">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="settingsModalLabel">Kolon Ayarları</h5>
@@ -88,7 +88,7 @@
 </div>
 
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog w-200">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="editModalLabel">Kayıt Düzenle</h5>
@@ -127,7 +127,7 @@
   </div>
 </div>
 <div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog w-200">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="addModalLabel">Yeni Kayıt</h5>
@@ -210,7 +210,7 @@
 
 
 <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog w-200">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Silme Onayı</h5>


### PR DESCRIPTION
## Summary
- enforce 200px width for all modals on the inventory add page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689efcfad36c832b826c0c2e5f2bafd2