### PR TITLE
Add admin user search and label request button

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -25,6 +25,10 @@
   </div>
   <button type="submit" class="btn btn-primary">Ekle</button>
 </form>
+<form method="get" action="/admin" class="mb-3 d-flex">
+  <input type="text" name="q" class="form-control me-2" placeholder="Kullanıcı Ara" value="{{ q }}">
+  <button type="submit" class="btn btn-secondary">Ara</button>
+</form>
 <table class="table">
   <thead>
     <tr><th>Kullanıcı Adı</th><th>İsim</th><th>Soyisim</th><th>Mail</th><th>Admin</th><th>İşlem</th></tr>

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -6,9 +6,7 @@
 </div>
 
 <div class="d-flex gap-2 mb-3">
-  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="width:40px;height:40px;display:flex;align-items:center;justify-content:center;">
-    <i class="bi bi-plus"></i>
-  </button>
+  <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal" style="height:40px;">Talep Aç</button>
   <button id="transfer-selected" type="button" class="btn btn-primary" style="height:40px;">Giriş</button>
   <button id="stock-transfer-selected" type="button" class="btn btn-warning" style="height:40px;">Stok Giriş</button>
   <button id="delete-selected" type="button" class="btn btn-danger" style="height:40px;">Sil</button>


### PR DESCRIPTION
## Summary
- replace request page plus icon with explicit "Talep Aç" label
- add search field to admin panel to filter users

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0c928a58832ba750e3684c3f3633