### PR TITLE
Fix missing lookup modals on inventory list page

### DIFF
--- a/templates/listeler.html
+++ b/templates/listeler.html
@@ -214,7 +214,221 @@
   </div>
 </div>
 
-<!-- Yazılım, Fabrika, Departman, Blok, Model, Yazıcı Markası, Yazıcı Modeli, Ürün modalları da aynen devam ediyor -->
+<!-- Yazılım Modal -->
+<div class="modal fade" id="yazilimModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Yazılım</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="yazilim">
+          <input class="form-control" type="text" name="name" placeholder="Yeni yazılım" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for s in softwares %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ s.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ s.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Fabrika Modal -->
+<div class="modal fade" id="fabrikaModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Fabrika</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="fabrika">
+          <input class="form-control" type="text" name="name" placeholder="Yeni fabrika" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for f in factories %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ f.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ f.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Departman Modal -->
+<div class="modal fade" id="departmanModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Departman</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="departman">
+          <input class="form-control" type="text" name="name" placeholder="Yeni departman" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for d in departments %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ d.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ d.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Blok Modal -->
+<div class="modal fade" id="blokModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Blok</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="blok">
+          <input class="form-control" type="text" name="name" placeholder="Yeni blok" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for b in blocks %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ b.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ b.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Model Modal -->
+<div class="modal fade" id="modelModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Model</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="model">
+          <input class="form-control" type="text" name="name" placeholder="Yeni model" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for m in models %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ m.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ m.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Yazıcı Markası Modal -->
+<div class="modal fade" id="yaziciMarkaModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Yazıcı Markası</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="yazici_marka">
+          <input class="form-control" type="text" name="name" placeholder="Yeni yazıcı markası" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for pb in printer_brands %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ pb.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ pb.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Yazıcı Modeli Modal -->
+<div class="modal fade" id="yaziciModelModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Yazıcı Modeli</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="yazici_model">
+          <input class="form-control" type="text" name="name" placeholder="Yeni yazıcı modeli" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for pm in printer_models %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ pm.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ pm.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Ürün Modal -->
+<div class="modal fade" id="urunModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Ürün Adı</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <form action="/lists/add" method="post" class="d-flex gap-2 mb-3">
+          <input type="hidden" name="item_type" value="urun">
+          <input class="form-control" type="text" name="name" placeholder="Yeni ürün" required>
+          <button class="btn btn-success" type="submit">Ekle</button>
+        </form>
+        <ol class="list-group list-group-numbered">
+          {% for p in products %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ p.name }}
+            <button class="btn btn-sm btn-danger delete-item" data-id="{{ p.id }}">Sil</button>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- add modal dialogs for software, factory, department, block, model, printer brand, printer model and product lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f0dffda38832b836a504083e22905