### PR TITLE
Add inventory logging and reporting utilities

### DIFF
--- a/db/migrations/001_inventory_logs.sql
+++ b/db/migrations/001_inventory_logs.sql
@@ -1,0 +1,24 @@
+-- Envanter hareket log tablosu
+CREATE TABLE IF NOT EXISTS inventory_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  inventory_type TEXT NOT NULL,           -- 'pc' | 'license' | 'accessory' | 'stock' ...
+  inventory_id INTEGER NOT NULL,          -- ilgili tablonun ID'si
+  old_user_id INTEGER,                    -- önceki kullanıcı (NULL olabilir)
+  new_user_id INTEGER,                    -- yeni kullanıcı (NULL olabilir, iade ise NULL)
+  old_location TEXT,                      -- önceki konum
+  new_location TEXT,                      -- yeni konum
+  action TEXT NOT NULL,                   -- 'assign' | 'return' | 'move' | 'relabel' ...
+  note TEXT,                              -- opsiyonel açıklama
+  changed_by INTEGER NOT NULL,            -- işlemi yapan admin / user ID
+  change_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Sorgu hızları için index'ler
+CREATE INDEX IF NOT EXISTS idx_inventory_logs_inv
+  ON inventory_logs (inventory_type, inventory_id);
+
+CREATE INDEX IF NOT EXISTS idx_inventory_logs_date
+  ON inventory_logs (change_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_inventory_logs_users
+  ON inventory_logs (old_user_id, new_user_id);

--- a/logs.py
+++ b/logs.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional, Literal
+from pydantic import BaseModel
+
+InventoryType = Literal['pc', 'license', 'accessory', 'stock']
+
+
+class InventoryLogCreate(BaseModel):
+    inventory_type: InventoryType
+    inventory_id: int
+    action: Literal['assign', 'return', 'move', 'relabel']
+    changed_by: int
+    old_user_id: Optional[int] = None
+    new_user_id: Optional[int] = None
+    old_location: Optional[str] = None
+    new_location: Optional[str] = None
+    note: Optional[str] = None
+
+
+class InventoryLog(BaseModel):
+    id: int
+    change_date: datetime
+    inventory_type: InventoryType
+    inventory_id: int
+    action: Literal['assign', 'return', 'move', 'relabel']
+    changed_by: int
+    old_user_id: Optional[int] = None
+    new_user_id: Optional[int] = None
+    old_location: Optional[str] = None
+    new_location: Optional[str] = None
+    note: Optional[str] = None

--- a/models.py
+++ b/models.py
@@ -207,6 +207,11 @@ class ActivityLog(Base):
 def init_db():
     """Create database tables if they don't exist."""
     Base.metadata.create_all(bind=engine)
+    mig_path = os.path.join(os.path.dirname(__file__), "db", "migrations", "001_inventory_logs.sql")
+    if os.path.exists(mig_path):
+        import sqlite3
+        with sqlite3.connect(DB_FILE) as con, open(mig_path, "r") as fh:
+            con.executescript(fh.read())
 
 
 def init_admin():

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -6,6 +6,8 @@ from .auth import router as auth_router
 from .hardware import router as hardware_router
 from .stock import router as stock_router
 from .reporting import router as reporting_router
+from .inventory_logs import router as inventory_logs_router
+from .reports import router as reports_router
 from .admin import router as admin_router
 from .inventory_pages import router as inventory_pages_router
 from .inventory import router as inventory_router
@@ -21,6 +23,8 @@ router.include_router(admin_router)
 router.include_router(inventory_pages_router)
 router.include_router(inventory_router)
 router.include_router(connections_router)
+router.include_router(inventory_logs_router)
+router.include_router(reports_router)
 router.include_router(trash_router)
 
 __all__ = ["router"]

--- a/routes/inventory_logs.py
+++ b/routes/inventory_logs.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter
+from typing import Optional
+from pydantic import BaseModel
+
+from logs import InventoryLogCreate
+from services.log_service import add_inventory_log, get_inventory_logs
+
+router = APIRouter(prefix="/logs", tags=["Inventory Logs"])
+
+@router.get("")
+def list_logs(type: Optional[str] = None, id: Optional[int] = None, limit: int = 200, offset: int = 0):
+    return get_inventory_logs(inventory_type=type, inventory_id=id, limit=limit, offset=offset)
+
+@router.post("")
+def create_log(payload: InventoryLogCreate):
+    log_id = add_inventory_log(payload)
+    return {"ok": True, "id": log_id}
+
+class AssignRequest(BaseModel):
+    inventory_type: str
+    inventory_id: int
+    to_user_id: int
+    changed_by: int
+    note: Optional[str] = None
+
+@router.post("/assign")
+def assign_item(req: AssignRequest):
+    old_user_id = None
+    add_inventory_log(
+        InventoryLogCreate(
+            inventory_type=req.inventory_type,
+            inventory_id=req.inventory_id,
+            action="assign",
+            changed_by=req.changed_by,
+            old_user_id=old_user_id,
+            new_user_id=req.to_user_id,
+            note=req.note,
+        )
+    )
+    return {"ok": True}
+
+class ReturnRequest(BaseModel):
+    inventory_type: str
+    inventory_id: int
+    from_user_id: int
+    changed_by: int
+    note: Optional[str] = None
+
+@router.post("/return")
+def return_item(req: ReturnRequest):
+    add_inventory_log(
+        InventoryLogCreate(
+            inventory_type=req.inventory_type,
+            inventory_id=req.inventory_id,
+            action="return",
+            changed_by=req.changed_by,
+            old_user_id=req.from_user_id,
+            new_user_id=None,
+            note=req.note,
+        )
+    )
+    return {"ok": True}
+
+class MoveRequest(BaseModel):
+    inventory_type: str
+    inventory_id: int
+    old_location: Optional[str]
+    new_location: str
+    changed_by: int
+    note: Optional[str] = None
+
+@router.post("/move")
+def move_item(req: MoveRequest):
+    add_inventory_log(
+        InventoryLogCreate(
+            inventory_type=req.inventory_type,
+            inventory_id=req.inventory_id,
+            action="move",
+            changed_by=req.changed_by,
+            old_location=req.old_location,
+            new_location=req.new_location,
+            note=req.note,
+        )
+    )
+    return {"ok": True}
+
+class RelabelRequest(BaseModel):
+    inventory_type: str
+    inventory_id: int
+    old_label: str
+    new_label: str
+    changed_by: int
+    note: Optional[str] = None
+
+@router.post("/relabel")
+def relabel_item(req: RelabelRequest):
+    add_inventory_log(
+        InventoryLogCreate(
+            inventory_type=req.inventory_type,
+            inventory_id=req.inventory_id,
+            action="relabel",
+            changed_by=req.changed_by,
+            note=f"Label: {req.old_label} -> {req.new_label}",
+        )
+    )
+    return {"ok": True}

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter
+import sqlite3
+
+router = APIRouter(prefix="/reports", tags=["Reports"])
+DB_PATH = "data/envanter.db"
+
+
+@router.get("/who-has-what")
+def who_has_what():
+    data = {}
+    with sqlite3.connect(DB_PATH) as con:
+        cur = con.cursor()
+        cur.execute(
+            "SELECT id, sorumlu_personel FROM hardware_inventory WHERE sorumlu_personel IS NOT NULL AND sorumlu_personel != ''"
+        )
+        data["pc"] = [{"pc_id": r[0], "user": r[1]} for r in cur.fetchall()]
+        cur.execute(
+            "SELECT id, kullanici FROM license_inventory WHERE kullanici IS NOT NULL AND kullanici != ''"
+        )
+        data["licenses"] = [{"license_id": r[0], "user": r[1]} for r in cur.fetchall()]
+        cur.execute(
+            "SELECT id, kullanici FROM accessory_inventory WHERE kullanici IS NOT NULL AND kullanici != ''"
+        )
+        data["accessories"] = [{"accessory_id": r[0], "user": r[1]} for r in cur.fetchall()]
+    return data

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -1,0 +1,63 @@
+import sqlite3
+from typing import List, Optional, Dict, Any
+
+from logs import InventoryLogCreate
+
+DB_PATH = "data/envanter.db"
+
+
+def _row_to_dict(cursor, row):
+    return {desc[0]: row[idx] for idx, desc in enumerate(cursor.description)}
+
+
+def add_inventory_log(payload: InventoryLogCreate) -> int:
+    q = """
+    INSERT INTO inventory_logs
+    (inventory_type, inventory_id, old_user_id, new_user_id, old_location, new_location, action, note, changed_by)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+    with sqlite3.connect(DB_PATH) as con:
+        cur = con.cursor()
+        cur.execute(
+            q,
+            (
+                payload.inventory_type,
+                payload.inventory_id,
+                payload.old_user_id,
+                payload.new_user_id,
+                payload.old_location,
+                payload.new_location,
+                payload.action,
+                payload.note,
+                payload.changed_by,
+            ),
+        )
+        con.commit()
+        return cur.lastrowid
+
+
+def get_inventory_logs(
+    inventory_type: Optional[str] = None,
+    inventory_id: Optional[int] = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    base = "SELECT * FROM inventory_logs"
+    conds: List[str] = []
+    params: List[Any] = []
+    if inventory_type:
+        conds.append("inventory_type = ?")
+        params.append(inventory_type)
+    if inventory_id is not None:
+        conds.append("inventory_id = ?")
+        params.append(inventory_id)
+    if conds:
+        base += " WHERE " + " AND ".join(conds)
+    base += " ORDER BY change_date DESC, id DESC LIMIT ? OFFSET ?"
+    params.extend([limit, offset])
+
+    with sqlite3.connect(DB_PATH) as con:
+        con.row_factory = _row_to_dict
+        cur = con.cursor()
+        cur.execute(base, params)
+        return cur.fetchall()

--- a/templates/partials/inventory_history.html
+++ b/templates/partials/inventory_history.html
@@ -1,0 +1,39 @@
+<div class="card mt-3">
+  <div class="card-header">Geçmiş</div>
+  <div class="card-body p-0">
+    <table class="table table-sm mb-0">
+      <thead>
+        <tr>
+          <th>Tarih</th>
+          <th>İşlem</th>
+          <th>Önceki Kullanıcı</th>
+          <th>Yeni Kullanıcı</th>
+          <th>Önceki Konum</th>
+          <th>Yeni Konum</th>
+          <th>Not</th>
+          <th>İşlemi Yapan</th>
+        </tr>
+      </thead>
+      <tbody id="history-rows"></tbody>
+    </table>
+  </div>
+</div>
+<script>
+async function loadHistory(invType, invId){
+  const res = await fetch(`/logs?type=${encodeURIComponent(invType)}&id=${invId}`);
+  const rows = await res.json();
+  const tbody = document.getElementById('history-rows');
+  tbody.innerHTML = rows.map(r => `
+    <tr>
+      <td>${new Date(r.change_date).toLocaleString()}</td>
+      <td>${r.action}</td>
+      <td>${r.old_user_id ?? ''}</td>
+      <td>${r.new_user_id ?? ''}</td>
+      <td>${r.old_location ?? ''}</td>
+      <td>${r.new_location ?? ''}</td>
+      <td>${r.note ?? ''}</td>
+      <td>${r.changed_by}</td>
+    </tr>
+  `).join('');
+}
+</script>


### PR DESCRIPTION
## Summary
- add migration and models for inventory log records
- expose log CRUD helpers and endpoints
- provide who-has-what reporting API and history partial

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2c3053dc832bb6b5f4c53c3f40d1