### PR TITLE
Add logs page in settings

### DIFF
--- a/routes/inventory_logs.py
+++ b/routes/inventory_logs.py
@@ -1,15 +1,24 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import HTMLResponse
 from typing import Optional
 from pydantic import BaseModel
 
 from logs import InventoryLogCreate
 from services.log_service import add_inventory_log, get_inventory_logs
+from utils import templates
+from utils.auth import require_admin
 
 router = APIRouter(prefix="/logs", tags=["Inventory Logs"])
 
 @router.get("")
 def list_logs(type: Optional[str] = None, id: Optional[int] = None, limit: int = 200, offset: int = 0):
     return get_inventory_logs(inventory_type=type, inventory_id=id, limit=limit, offset=offset)
+
+
+@router.get("/records", response_class=HTMLResponse, dependencies=[Depends(require_admin)])
+def logs_page(request: Request, limit: int = 200, offset: int = 0):
+    logs = get_inventory_logs(limit=limit, offset=offset)
+    return templates.TemplateResponse("kayitlar.html", {"request": request, "logs": logs})
 
 @router.post("")
 def create_log(payload: InventoryLogCreate):

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,6 +64,7 @@
         {% if request.session.get('is_admin') %}
         <li><a href="/admin" class="nav-link text-white {% if request.path.startswith('/admin') %}active{% endif %}">Admin Paneli</a></li>
         <li><a href="/connections" class="nav-link text-white {% if request.path.startswith('/connections') %}active{% endif %}">Bağlantılar</a></li>
+        <li><a href="/logs/records" class="nav-link text-white {% if request.path.startswith('/logs') %}active{% endif %}">Kayıtlar</a></li>
         {% endif %}
         <li><a href="/lists" class="nav-link text-white {% if request.path.startswith('/lists') %}active{% endif %}">Envanter Ekleme</a></li>
       </ul>

--- a/templates/kayitlar.html
+++ b/templates/kayitlar.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Kayıtlar{% endblock %}
+{% block content %}
+<h2>Kayıtlar</h2>
+<table class="table table-striped table-fixed">
+  <thead>
+    <tr>
+      <th>Tarih</th>
+      <th>Tür</th>
+      <th>ID</th>
+      <th>İşlem</th>
+      <th>Eski Kullanıcı</th>
+      <th>Yeni Kullanıcı</th>
+      <th>Eski Konum</th>
+      <th>Yeni Konum</th>
+      <th>Not</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for log in logs %}
+    <tr>
+      <td>{{ log.change_date }}</td>
+      <td>{{ log.inventory_type }}</td>
+      <td>{{ log.inventory_id }}</td>
+      <td>{{ log.action }}</td>
+      <td>{{ log.old_user_id or '' }}</td>
+      <td>{{ log.new_user_id or '' }}</td>
+      <td>{{ log.old_location or '' }}</td>
+      <td>{{ log.new_location or '' }}</td>
+      <td>{{ log.note or '' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add HTML page to list inventory logs
- Link logs page from Settings
- Secure access to logs with admin-only view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3154a2b0832b929d271a558fd51a