### PR TITLE
Log user assignment changes and expose user history reports

### DIFF
--- a/routes/inventory_logs.py
+++ b/routes/inventory_logs.py
@@ -11,8 +11,20 @@ from utils.auth import require_admin
 router = APIRouter(prefix="/logs", tags=["Inventory Logs"])
 
 @router.get("")
-def list_logs(type: Optional[str] = None, id: Optional[int] = None, limit: int = 200, offset: int = 0):
-    return get_inventory_logs(inventory_type=type, inventory_id=id, limit=limit, offset=offset)
+def list_logs(
+    type: Optional[str] = None,
+    id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    limit: int = 200,
+    offset: int = 0,
+):
+    return get_inventory_logs(
+        inventory_type=type,
+        inventory_id=id,
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get("/records", response_class=HTMLResponse, dependencies=[Depends(require_admin)])

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Query
 import sqlite3
+from services.log_service import get_inventory_logs
 
 router = APIRouter(prefix="/reports", tags=["Reports"])
 DB_PATH = "data/envanter.db"
@@ -64,3 +65,8 @@ def current_assignments(
         }
         for r in rows
     ]
+
+
+@router.get("/user-history")
+def user_history(user_id: int, limit: int = 200, offset: int = 0):
+    return get_inventory_logs(user_id=user_id, limit=limit, offset=offset)

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -41,6 +41,7 @@ def add_inventory_log(payload: InventoryLogCreate) -> int:
 def get_inventory_logs(
     inventory_type: Optional[str] = None,
     inventory_id: Optional[int] = None,
+    user_id: Optional[int] = None,
     limit: int = 200,
     offset: int = 0,
 ) -> List[Dict[str, Any]]:
@@ -53,6 +54,9 @@ def get_inventory_logs(
     if inventory_id is not None:
         conds.append("inventory_id = ?")
         params.append(inventory_id)
+    if user_id is not None:
+        conds.append("(old_user_id = ? OR new_user_id = ?)")
+        params.extend([user_id, user_id])
     if conds:
         base += " WHERE " + " AND ".join(conds)
     base += " ORDER BY change_date DESC, id DESC LIMIT ? OFFSET ?"

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -1,0 +1,94 @@
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import os
+import sys
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from starlette.middleware.sessions import SessionMiddleware
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import models
+import routes.inventory as inventory_module
+from routes.inventory import router as inventory_router
+from routes import reports as reports_module
+from utils.auth import require_login
+import services.log_service as log_service
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.engine = engine
+    models.SessionLocal = TestingSessionLocal
+    inventory_module.SessionLocal = TestingSessionLocal
+    models.Base.metadata.create_all(bind=engine)
+
+
+def create_app():
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test")
+    app.include_router(inventory_router)
+    app.include_router(reports_module.router)
+    app.dependency_overrides[require_login] = lambda: None
+    return app
+
+
+def setup_log_db(path):
+    con = sqlite3.connect(path)
+    for mig in ["001_inventory_logs.sql", "003_add_inventory_no_columns.sql"]:
+        with open(f"db/migrations/{mig}") as f:
+            con.executescript(f.read())
+    con.commit()
+    con.close()
+
+
+def test_user_history_returns_assignment_changes(tmp_path):
+    setup_db()
+    log_db = tmp_path / "log.db"
+    setup_log_db(log_db)
+    log_service.DB_PATH = str(log_db)
+    reports_module.DB_PATH = str(log_db)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/inventory/add",
+            data={"no": "001", "donanim_tipi": "Laptop", "sorumlu_personel": "1"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        db = models.SessionLocal()
+        item_id = db.query(models.HardwareInventory).first().id
+        db.close()
+        resp = client.post(
+            "/inventory/add",
+            data={
+                "item_id": item_id,
+                "no": "001",
+                "donanim_tipi": "Laptop",
+                "sorumlu_personel": "2",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        resp = client.get("/reports/user-history?user_id=2")
+        assert resp.status_code == 200
+        logs = resp.json()
+        assert len(logs) == 1
+        assert logs[0]["old_user_id"] == 1
+        assert logs[0]["new_user_id"] == 2
+        resp = client.get("/reports/user-history?user_id=1")
+        assert resp.status_code == 200
+        logs = resp.json()
+        assert len(logs) == 1
+        assert logs[0]["old_user_id"] == 1
+        assert logs[0]["new_user_id"] == 2


### PR DESCRIPTION
## Summary
- log user assignment changes on inventory updates
- allow filtering inventory logs by user
- add user history report endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f39fe48f4832ba3175dba0f031321