### PR TITLE
Show inventory history in edit modals

### DIFF
--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -107,6 +107,7 @@
             </div>
             {% endif %}
             {% endfor %}
+            {% include 'partials/inventory_history.html' %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -319,6 +320,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
+    loadHistory(tableName, form.accessory_id.value);
 });
 
 const perPageSelect = document.getElementById('per-page');

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -117,6 +117,7 @@
             {% endfor %}
             <input type="hidden" name="tarih" value="{{ today }}">
             </div>
+            {% include 'partials/inventory_history.html' %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -344,6 +345,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
+    loadHistory(tableName, form.item_id.value);
 });
 
 const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -112,6 +112,7 @@
             </div>
             {% endif %}
             {% endfor %}
+            {% include 'partials/inventory_history.html' %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -336,6 +337,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
+    loadHistory(tableName, form.license_id.value);
 });
 
 const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -118,6 +118,7 @@
               </div>
               {% endif %}
               {% endfor %}
+              {% include 'partials/inventory_history.html' %}
             </div>
           <div class="modal-footer">
             <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -345,6 +346,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
+    loadHistory(tableName, form.stock_id.value);
 });
 
 const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -109,6 +109,7 @@
             </div>
             {% endif %}
             {% endfor %}
+            {% include 'partials/inventory_history.html' %}
           </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-warning">Kaydet</button>
@@ -334,6 +335,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
+    loadHistory(tableName, form.printer_id.value);
 });
 
 const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));


### PR DESCRIPTION
## Summary
- Include `inventory_history` partial in edit modals for hardware, accessories, printers, stock, and license pages
- Load history entries with `loadHistory` when an edit modal opens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3c723e0c832b966b562d7721abb0