### PR TITLE
Add selectable log view for inventory and user activity

### DIFF
--- a/templates/kayitlar.html
+++ b/templates/kayitlar.html
@@ -2,6 +2,44 @@
 {% block title %}Kayıtlar{% endblock %}
 {% block content %}
 <h2>Kayıtlar</h2>
+
+<form method="get" class="mb-3">
+  <label for="log_type">Log türü:</label>
+  <select id="log_type" name="log_type" onchange="this.form.submit()">
+    <option value="inventory" {% if log_type != 'activity' %}selected{% endif %}>Envanter</option>
+    <option value="activity" {% if log_type == 'activity' %}selected{% endif %}>Kullanıcı</option>
+  </select>
+  {% if log_type != 'activity' %}
+  <label for="user_id" class="ms-3">Kullanıcı:</label>
+  <select id="user_id" name="user_id" onchange="this.form.submit()">
+    <option value="">Hepsi</option>
+    {% for u in users %}
+      <option value="{{ u.id }}" {% if selected_user_id == u.id %}selected{% endif %}>{{ u.username }}</option>
+    {% endfor %}
+  </select>
+  {% endif %}
+</form>
+
+{% if log_type == 'activity' %}
+<table class="table table-striped table-fixed">
+  <thead>
+    <tr>
+      <th>Tarih</th>
+      <th>Kullanıcı</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for log in logs %}
+    <tr>
+      <td>{{ log.timestamp }}</td>
+      <td>{{ log.username }}</td>
+      <td>{{ log.action }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% else %}
 <table class="table table-striped table-fixed">
   <thead>
     <tr>
@@ -23,8 +61,8 @@
       <td>{{ log.inventory_type }}</td>
       <td>{{ log.inventory_id }}</td>
       <td>{{ log.action }}</td>
-      <td>{{ log.old_user_id or '' }}</td>
-      <td>{{ log.new_user_id or '' }}</td>
+      <td>{{ log.old_user_name or '' }}</td>
+      <td>{{ log.new_user_name or '' }}</td>
       <td>{{ log.old_location or '' }}</td>
       <td>{{ log.new_location or '' }}</td>
       <td>{{ log.note or '' }}</td>
@@ -32,4 +70,5 @@
   {% endfor %}
   </tbody>
 </table>
+{% endif %}
 {% endblock %}

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -48,6 +48,12 @@ def setup_log_db(path):
     for mig in ["001_inventory_logs.sql", "003_add_inventory_no_columns.sql"]:
         with open(f"db/migrations/{mig}") as f:
             con.executescript(f.read())
+    # minimal users table for join in get_inventory_logs
+    con.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)")
+    con.executemany(
+        "INSERT INTO users (id, username) VALUES (?, ?)",
+        [(1, "user1"), (2, "user2")],
+    )
     con.commit()
     con.close()
 


### PR DESCRIPTION
## Summary
- Allow records page to toggle between inventory and user activity logs
- Add `get_activity_logs` service and route logic to fetch activity logs
- Update template to conditionally render tables based on selected log type
- Filter inventory logs by user and show usernames on records page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3e131f60832b9a86ae4eb9270440