### PR TITLE
Fix IFS number retrieval for request transfer

### DIFF
--- a/templates/talep.html
+++ b/templates/talep.html
@@ -192,7 +192,7 @@ document.getElementById('transfer-selected').addEventListener('click', function(
   checks.forEach(cb => {
     const tr = cb.closest('tr');
     const urun = tr.children[1].innerText.trim();
-    const ifsNo = tr.children[4].innerText.trim();
+    const ifsNo = tr.children[3].innerText.trim();
     const maxQty = parseInt(tr.children[2].innerText.trim());
     const div = document.createElement('div');
     div.className = 'transfer-row d-flex flex-column gap-2';


### PR DESCRIPTION
## Summary
- Correct transfer modal to read IFS number from the proper table column

## Testing
- `pytest`
- JavaScript simulation confirming IFS number prepopulates the Envanter No field


------
https://chatgpt.com/codex/tasks/task_e_68a33c6e181c832b8ec0e0646972d35e