### PR TITLE
Add stock status summary endpoint

### DIFF
--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -2,9 +2,12 @@
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
 
 from utils.auth import require_login
 from utils import templates
+from models import StockItem, get_db
 
 router = APIRouter(dependencies=[Depends(require_login)])
 
@@ -34,9 +37,29 @@ def home_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/stock/status", response_class=HTMLResponse)
-def stock_status_page(request: Request) -> HTMLResponse:
+def stock_status_page(
+    request: Request, db: Session = Depends(get_db)
+) -> HTMLResponse:
     """Render simple stock status page."""
-    return templates.TemplateResponse(request, "stok_durumu.html")
+
+    totals = (
+        db.query(
+            StockItem.urun_adi,
+            func.sum(
+                case(
+                    (StockItem.islem == "giris", StockItem.adet),
+                    else_=-StockItem.adet,
+                )
+            ).label("net_adet"),
+        )
+        .group_by(StockItem.urun_adi)
+        .all()
+    )
+
+    summary = [(name, qty or 0) for name, qty in totals]
+    return templates.TemplateResponse(
+        request, "stok_durumu.html", {"summary": summary}
+    )
 
 
 @router.get("/ping")


### PR DESCRIPTION
## Summary
- Summarize stock quantities by product using SQLAlchemy
- Return aggregated data to the stock status template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40dbac1a0832baadea6392ce58fce