### PR TITLE
Add accessory and stock inventory support

### DIFF
--- a/services/log_service.py
+++ b/services/log_service.py
@@ -132,6 +132,8 @@ def get_inventory_items() -> List[Dict[str, Any]]:
     parts = [
         ("pc", "hardware_inventory", "bilgisayar_adi", "no"),
         ("license", "license_inventory", "yazilim_adi", "envanter_no"),
+        ("accessory", "accessory_inventory", "urun_adi", "ifs_no"),
+        ("stock", "stock_tracking", "urun_adi", "id"),
     ]
     with sqlite3.connect(DB_PATH) as con:
         cur = con.cursor()


### PR DESCRIPTION
## Summary
- extend `get_inventory_items` to include accessory and stock records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a42126f618832b992ef5d2afbf626c