### PR TITLE
Handle mixed inventory numbers

### DIFF
--- a/services/log_service.py
+++ b/services/log_service.py
@@ -146,9 +146,17 @@ def get_inventory_items() -> List[Dict[str, Any]]:
                 rows.extend(cur.fetchall())
             except sqlite3.OperationalError:
                 continue
-    rows.sort(key=lambda r: (r[3] or ""))
+    # Ensure the inventory number is treated as a string when sorting so that
+    # numeric IDs (e.g., from stock items) don't cause comparisons between
+    # ``int`` and ``str`` types.
+    rows.sort(key=lambda r: str(r[3]) if r[3] is not None else "")
     return [
-        {"type": r[0], "id": r[1], "name": r[2], "inv_no": r[3]}
+        {
+            "type": r[0],
+            "id": r[1],
+            "name": r[2],
+            "inv_no": str(r[3]) if r[3] is not None else None,
+        }
         for r in rows
     ]
 

--- a/tests/test_get_inventory_items_sort.py
+++ b/tests/test_get_inventory_items_sort.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import sqlite3
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import services.log_service as log_service
+
+
+def test_get_inventory_items_handles_mixed_number_types(tmp_path):
+    db_path = tmp_path / "inv.db"
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "CREATE TABLE hardware_inventory (id INTEGER PRIMARY KEY, bilgisayar_adi TEXT, no TEXT)"
+    )
+    con.execute(
+        "CREATE TABLE stock_tracking (id INTEGER PRIMARY KEY, urun_adi TEXT)"
+    )
+    con.execute(
+        "INSERT INTO hardware_inventory (id, bilgisayar_adi, no) VALUES (1, 'Laptop', 'ABC123')"
+    )
+    con.execute(
+        "INSERT INTO stock_tracking (id, urun_adi) VALUES (2, 'Mouse')"
+    )
+    con.commit()
+    con.close()
+
+    original_path = log_service.DB_PATH
+    log_service.DB_PATH = str(db_path)
+    try:
+        items = log_service.get_inventory_items()
+    finally:
+        log_service.DB_PATH = original_path
+
+    assert items == [
+        {"type": "stock", "id": 2, "name": "Mouse", "inv_no": "2"},
+        {"type": "pc", "id": 1, "name": "Laptop", "inv_no": "ABC123"},
+    ]


### PR DESCRIPTION
## Summary
- Normalize inventory number fields to strings during sorting and output
- Add regression test ensuring inventory items with numeric IDs don't cause TypeError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a431feb450832b9c9331e8b11bde9d