### PR TITLE
Log stock changes with inventory history

### DIFF
--- a/templates/stok.html
+++ b/templates/stok.html
@@ -354,7 +354,7 @@ editButton.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('editModal'));
     modal.show();
-    loadHistory(tableName, form.stock_id.value);
+    loadHistory('stock', form.stock_id.value);
 });
 
 const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));


### PR DESCRIPTION
## Summary
- Record stock additions and transfers using `add_inventory_log` for consistent inventory history
- Display stock log history in edit modal via `loadHistory('stock', id)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a439cf75ac832b95778d1b993a598c