### PR TITLE
Require category for stock operations and page filtering

### DIFF
--- a/routes/inventory.py
+++ b/routes/inventory.py
@@ -107,6 +107,9 @@ def _soft_delete(ids: list[int], model, deleted_model, db: Session) -> None:
 async def stock_add(request: Request, db: Session = Depends(get_db)):
     """Create or update a stock item from form data."""
     form = await request.form()
+    kategori = form.get("kategori")
+    if not kategori:
+        return JSONResponse({"detail": "kategori gerekli"}, status_code=400)
     stock_id = form.get("stock_id")
     if stock_id:
         item = db.get(StockItem, int(stock_id))
@@ -135,7 +138,7 @@ async def stock_add(request: Request, db: Session = Depends(get_db)):
     else:
         item = StockItem(
             urun_adi=form.get("urun_adi"),
-            kategori=form.get("kategori"),
+            kategori=kategori,
             marka=form.get("marka"),
             adet=int(form.get("adet") or 0),
             departman=form.get("departman"),
@@ -155,7 +158,7 @@ async def stock_add(request: Request, db: Session = Depends(get_db)):
         db.add(item)
         action = f"Added stock item {item.id}"
     log_action(db, request.session.get("username", ""), action)
-    return RedirectResponse("/stock", status_code=303)
+    return RedirectResponse(f"/stock?kategori={kategori}", status_code=303)
 
 
 @router.get("/stock", response_class=HTMLResponse)

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -83,10 +83,13 @@ def list_stock(
 async def add_stock(request: Request, db: Session = Depends(get_db)):
     """Add a stock item."""
     form = await request.form()
+    kategori = form.get("kategori")
+    if not kategori:
+        return JSONResponse({"detail": "kategori gerekli"}, status_code=400)
     item = StockItem(
             urun_adi=form.get("urun_adi"),
             adet=int(form.get("adet") or 0),
-            kategori=form.get("kategori"),
+            kategori=kategori,
             marka=form.get("marka"),
             departman=form.get("departman"),
             guncelleme_tarihi=date.fromisoformat(form.get("guncelleme_tarihi")) if form.get("guncelleme_tarihi") else None,
@@ -114,7 +117,7 @@ async def add_stock(request: Request, db: Session = Depends(get_db)):
         request.session.get("username", ""),
         f"Added stock item {item.id}",
     )
-    return RedirectResponse("/stock", status_code=303)
+    return RedirectResponse(f"/stock?kategori={kategori}", status_code=303)
 
 
 @router.post("/transfer")

--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -86,6 +86,7 @@
       </div>
       <form id="editForm" action="/accessories/add" method="post">
         <input type="hidden" name="accessory_id">
+        <input type="hidden" name="kategori" value="inventory">
           <div class="modal-body">
             <div class="row g-3">
             {% for col in columns %}
@@ -130,6 +131,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/accessories/add" method="post">
+          <input type="hidden" name="kategori" value="inventory">
           <div class="modal-body">
             <div class="row g-3">
               <div class="col-md-4 mb-3">

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -88,6 +88,7 @@
       </div>
       <form id="editForm" action="/inventory/add" method="post">
         <input type="hidden" name="item_id">
+        <input type="hidden" name="kategori" value="inventory">
           <div class="modal-body">
             <div class="row row-cols-4 g-3">
             {% for col in columns %}
@@ -126,6 +127,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/inventory/add" method="post">
+          <input type="hidden" name="kategori" value="inventory">
           <div class="modal-body">
             <div class="row row-cols-4 g-3">
             {% for col in columns %}

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -91,6 +91,7 @@
       </div>
       <form id="editForm" action="/license/add" method="post">
         <input type="hidden" name="license_id">
+        <input type="hidden" name="kategori" value="license">
           <div class="modal-body">
             <div class="row g-3">
             {% for col in columns %}
@@ -135,6 +136,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/license/add" method="post">
+          <input type="hidden" name="kategori" value="license">
           <div class="modal-body">
             <div class="row g-3">
               {% for col in columns %}

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -15,8 +15,8 @@
 {% block title %}Stok Takip{% endblock %}
 {% block content %}
 <div class="mb-3">
-  <a href="/stock?kategori=envanter" class="btn btn-outline-primary {% if active_tab == 'envanter' %}active{% endif %}">Envanter</a>
-  <a href="/stock?kategori=lisans" class="btn btn-outline-primary {% if active_tab == 'lisans' %}active{% endif %}">Lisans</a>
+  <a href="/stock?kategori=inventory" class="btn btn-outline-primary {% if active_tab == 'inventory' %}active{% endif %}">Envanter</a>
+  <a href="/stock?kategori=license" class="btn btn-outline-primary {% if active_tab == 'license' %}active{% endif %}">Lisans</a>
 </div>
 <div class="d-flex justify-content-between align-items-center">
   <h2>Stok Takibi</h2>
@@ -98,6 +98,7 @@
       </div>
         <form id="editForm" action="/stock/add" method="post">
           <input type="hidden" name="stock_id">
+          <input type="hidden" name="kategori" value="{{ active_tab }}">
             <div class="modal-body">
               {% for col in columns %}
               {% if col != 'islem_yapan' %}
@@ -142,6 +143,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <form id="addForm" action="/stock/add" method="post">
+        <input type="hidden" name="kategori" value="{{ active_tab }}">
         <div class="modal-body">
           <div class="row g-3">
             {% for col in columns %}
@@ -203,14 +205,14 @@
     {% set start = ((page - 1) // 10) * 10 + 1 %}
     {% set end = start + 9 if start + 9 < total_pages else total_pages %}
     {% if page > 1 %}
-    <li class="page-item"><a class="page-link" href="/stock?page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
+    <li class="page-item"><a class="page-link" href="/stock?kategori={{ active_tab }}&page={{ page - 1 }}&per_page={{ per_page }}&q={{ q }}">Önceki</a></li>
     {% endif %}
     {% for p in range(start, end + 1) %}
-    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/stock?page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
+    <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="/stock?kategori={{ active_tab }}&page={{ p }}&per_page={{ per_page }}&q={{ q }}">{{ p }}</a></li>
     {% endfor %}
     {% if page < total_pages %}
-    <li class="page-item"><a class="page-link" href="/stock?page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
-    <li class="page-item"><a class="page-link" href="/stock?page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
+    <li class="page-item"><a class="page-link" href="/stock?kategori={{ active_tab }}&page={{ page + 1 }}&per_page={{ per_page }}&q={{ q }}">Sonraki</a></li>
+    <li class="page-item"><a class="page-link" href="/stock?kategori={{ active_tab }}&page={{ total_pages }}&per_page={{ per_page }}&q={{ q }}">&raquo;&raquo;</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/tests/test_inventory_routes.py
+++ b/tests/test_inventory_routes.py
@@ -58,10 +58,12 @@ def test_stock_router_lists_added_items():
     app = create_app()
     with TestClient(app) as client:
         resp = client.post(
-            "/stock/add", data={"urun_adi": "Mouse", "adet": "5"}, follow_redirects=False
+            "/stock/add",
+            data={"urun_adi": "Mouse", "adet": "5", "kategori": "inventory"},
+            follow_redirects=False,
         )
         assert resp.status_code == 303
-        resp = client.get("/stock")
+        resp = client.get("/stock", params={"kategori": "inventory"})
         assert resp.status_code == 200
         assert "Mouse" in resp.text
 


### PR DESCRIPTION
## Summary
- Enforce `kategori` field in stock creation routes and preserve selected category on redirect.
- Update stock templates to carry category filter through tabs, forms, and pagination.
- Include category values in license, accessory, and inventory forms and adjust tests for new requirement.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a43b8404f4832bbbafa5bc68bb7cfa