### PR TITLE
Add stock entry modal to inventory-related pages

### DIFF
--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -35,6 +35,9 @@
   <button id="edit-selected" type="button" class="btn btn-warning d-flex align-items-center gap-1">
     <i class="bi bi-pencil"></i> Düzenle
   </button>
+  <button class="btn btn-primary d-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#stockModal">
+    <i class="bi bi-box-arrow-in-down"></i> Stock Giriş
+  </button>
   <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-nowrap">
     <input type="text" name="q" value="{{ q }}" class="form-control" placeholder="Ara..." style="max-width:200px;">
     <div class="position-relative d-flex gap-2">
@@ -166,10 +169,13 @@
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
-      </form>
+  </form>
     </div>
   </div>
 </div>
+
+{% set stock_category = 'inventory' %}
+{% include 'partials/stock_add_modal.html' %}
 
 <table class="table table-striped table-fixed table-resizable">
   <tr>

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -40,6 +40,9 @@
   <button id="delete-selected" type="button" class="btn btn-danger d-flex align-items-center gap-1">
     <i class="bi bi-trash"></i> Sil
   </button>
+  <button class="btn btn-primary d-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#stockModal">
+    <i class="bi bi-box-arrow-in-down"></i> Stock Giriş
+  </button>
   <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-nowrap">
     <input type="text" name="q" value="{{ q }}" class="form-control form-control-sm" placeholder="Ara..." style="max-width:200px;">
     <div class="position-relative d-flex gap-2">
@@ -153,10 +156,13 @@
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Ekle</button>
         </div>
-      </form>
+  </form>
     </div>
   </div>
 </div>
+
+{% set stock_category = 'inventory' %}
+{% include 'partials/stock_add_modal.html' %}
 
   <div class="table-scroll">
     <table class="table table-sm table-striped table-hover table-fixed table-resizable mb-0">

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -40,6 +40,9 @@
   <button id="delete-selected" type="button" class="btn btn-danger d-flex align-items-center gap-1">
     <i class="bi bi-trash"></i> Sil
   </button>
+  <button class="btn btn-primary d-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#stockModal">
+    <i class="bi bi-box-arrow-in-down"></i> Stock Giriş
+  </button>
   <form id="search-form" method="get" class="d-flex gap-2 align-items-center flex-nowrap">
     <input type="text" name="q" value="{{ q }}" class="form-control" placeholder="Ara..." style="max-width:200px;">
     <div class="position-relative d-flex gap-2">
@@ -171,6 +174,9 @@
     </div>
   </div>
 </div>
+
+{% set stock_category = 'license' %}
+{% include 'partials/stock_add_modal.html' %}
 
 <table class="table table-striped table-fixed table-resizable">
   <thead>

--- a/templates/partials/stock_add_modal.html
+++ b/templates/partials/stock_add_modal.html
@@ -1,0 +1,56 @@
+<div class="modal fade" id="stockModal" tabindex="-1" aria-labelledby="stockModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="stockModalLabel">Stok Girişi</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form action="/stock/add" method="post">
+        <input type="hidden" name="kategori" value="{{ stock_category }}">
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Ürün Adı</label>
+              <input type="text" class="form-control" name="urun_adi" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Marka</label>
+              <input type="text" class="form-control" name="marka">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Adet</label>
+              <input type="number" class="form-control" name="adet" min="0" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Departman</label>
+              <input type="text" class="form-control" name="departman">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Güncelleme Tarihi</label>
+              <input type="date" class="form-control" name="guncelleme_tarihi">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">İşlem</label>
+              <input type="text" class="form-control" name="islem">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Tarih</label>
+              <input type="date" class="form-control" name="tarih">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">IFS No</label>
+              <input type="text" class="form-control" name="ifs_no">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Açıklama</label>
+              <textarea class="form-control" name="aciklama"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Ekle</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Add "Stock Giriş" button on accessory, hardware inventory, and license pages
- Provide reusable modal for creating stock entries, posting to `/stock/add`
- Prefill modal `kategori` based on page context (`inventory` or `license`)

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a43d839a28832bbd4e7718c93c89f4