### PR TITLE
Add navigation between inventory and license stock views

### DIFF
--- a/routes/inventory_pages.py
+++ b/routes/inventory_pages.py
@@ -262,10 +262,22 @@ def license_page(
     }
 
     token, signed = csrf_protect.generate_csrf_tokens()
+    columns = [
+        "departman",
+        "kullanici",
+        "yazilim_adi",
+        "lisans_anahtari",
+        "mail_adresi",
+        "envanter_no",
+        "notlar",
+        "ifs_no",
+        "tarih",
+        "islem_yapan",
+    ]
     context = {
         "request": request,
         "licenses": licenses,
-        "columns": get_table_columns(LicenseInventory.__tablename__),
+        "columns": columns,
         "column_widths": {},
         "lookups": lookups,
         "offset": offset,
@@ -282,6 +294,7 @@ def license_page(
         "users": user_list,
         "current_user_id": request.session.get("user_id"),
         "csrf_token": token,
+        "active_tab": "license",
     }
     response = templates.TemplateResponse(request, "lisans.html", context)
     csrf_protect.set_csrf_cookie(signed, response)

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -61,6 +61,17 @@ def list_stock(
     """Render stock list using the common helper with optional category filter."""
     utils.engine = db.get_bind()
     params = list(request.query_params.multi_items())
+
+    existing_kategori_filter = any(
+        f == "filter_field" and v == "kategori" for f, v in params
+    )
+
+    if kategori == "license":
+        return RedirectResponse("/license")
+
+    if kategori is None and not existing_kategori_filter:
+        kategori = "inventory"
+
     if kategori:
         params.append(("filter_field", "kategori"))
         params.append(("filter_value", kategori))

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -13,6 +13,10 @@
 } %}
 {% block title %}Lisans Takip{% endblock %}
 {% block content %}
+<div class="mb-3">
+  <a href="/stock" class="btn btn-outline-primary {% if active_tab == 'inventory' %}active{% endif %}">Envanter</a>
+  <a href="/license" class="btn btn-outline-primary {% if active_tab == 'license' %}active{% endif %}">Lisans</a>
+</div>
 <div class="d-flex justify-content-between align-items-center">
   <h2>Lisans Envanteri</h2>
   <span class="badge bg-secondary">{{ count }} kayıt var</span>

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -15,8 +15,8 @@
 {% block title %}Stok Takip{% endblock %}
 {% block content %}
 <div class="mb-3">
-  <a href="/stock?kategori=inventory" class="btn btn-outline-primary {% if active_tab == 'inventory' %}active{% endif %}">Envanter</a>
-  <a href="/stock?kategori=license" class="btn btn-outline-primary {% if active_tab == 'license' %}active{% endif %}">Lisans</a>
+  <a href="/stock" class="btn btn-outline-primary {% if active_tab == 'inventory' %}active{% endif %}">Envanter</a>
+  <a href="/license" class="btn btn-outline-primary {% if active_tab == 'license' %}active{% endif %}">Lisans</a>
 </div>
 <div class="d-flex justify-content-between align-items-center">
   <h2>Stok Takibi</h2>


### PR DESCRIPTION
## Summary
- Default stock tracking to inventory items and redirect license tab to license page
- Add navigation buttons for Inventory and License tables on stock and license pages
- Order license table columns to show notes before IFS number and track active tab

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a443252574832bb3ecaedf6c91197b