### PR TITLE
Add stock transfer endpoint with logging

### DIFF
--- a/routes/stock.py
+++ b/routes/stock.py
@@ -241,6 +241,7 @@ async def transfer_stock(request: Request, db: Session = Depends(get_db)):
 
     stock.adet = (stock.adet or 0) - qty
     db.commit()
+    db.refresh(stock)
 
     add_inventory_log(
         InventoryLogCreate(
@@ -258,4 +259,4 @@ async def transfer_stock(request: Request, db: Session = Depends(get_db)):
         request.session.get("username", ""),
         f"Transferred {qty} of stock item {stock.id} to {target}",
     )
-    return JSONResponse({"status": "ok"})
+    return JSONResponse({"status": "ok", "remaining": stock.adet})


### PR DESCRIPTION
## Summary
- handle stock transfers to target inventory tables
- update remaining stock count and refresh DB state
- log each transfer via `log_action`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4694c4434832b8cb242e4d29461df