### PR TITLE
Revamp dashboard layout and styling

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,16 @@
   {% endif %}
   <style>
     *{ box-sizing: border-box; }
-    body{ margin:0; font-family: Arial, sans-serif; color:#111; overflow-x:hidden; }
+    body{
+      margin:0;
+      font-family: Arial, sans-serif;
+      color:#111;
+      overflow-x:hidden;
+      background:#fff;
+      background-image:
+        repeating-linear-gradient(45deg, rgba(0,123,255,.2) 0, rgba(0,123,255,.2) 2px, transparent 2px, transparent 20px),
+        repeating-linear-gradient(-45deg, rgba(0,123,255,.1) 0, rgba(0,123,255,.1) 1px, transparent 1px, transparent 25px);
+    }
     .table-container{ width:100%; overflow:auto; }
     .table-fixed{ table-layout:auto; width:max-content; min-width:100%; }
     .table-fixed td{ white-space:normal; word-break:break-word; }

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,60 +1,58 @@
 {% extends "base.html" %}
 {% block title %}Ana Sayfa{% endblock %}
 {% block content %}
-<h1>Fabrika Envanteri</h1>
+<h1 class="text-center my-4">Hoş Geldiniz</h1>
+
 <div class="row">
-  {% for factory, categories in factories.items() %}
-  <div class="col-md-4 mb-3">
-    <div class="card">
-      <div class="card-header">{{ factory }}</div>
-      <ol class="list-group list-group-flush list-group-numbered">
-        {% for cat in categories %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          {{ cat.donanim_tipi }}
-          <span class="badge bg-primary rounded-pill">{{ cat.adet }}</span>
-        </li>
-        {% endfor %}
-      </ol>
-    </div>
+  <div class="col-md-6 mb-4">
+    <h2>Cihaz Sayıları</h2>
+    <ol class="list-group list-group-numbered">
+      {% for name, count in device_summary %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        {{ name }}
+        <span class="badge bg-primary rounded-pill">{{ count }}</span>
+      </li>
+      {% endfor %}
+    </ol>
   </div>
-  {% endfor %}
-</div>
 
-<div class="mt-4">
-  <h2>Donanım Dağılımı</h2>
-  <canvas id="hardwareChart"></canvas>
-</div>
-
-<div class="mt-4">
-  <h2>Son İşlemler</h2>
-  <div class="card">
-    <ol class="list-group list-group-flush list-group-numbered">
-      {% for log in actions %}
-      <li class="list-group-item">
-        {{ log.timestamp }} - {{ log.username }} = {{ log.action }}
+  <div class="col-md-6 mb-4">
+    <h2>Stok Durumu</h2>
+    <ol class="list-group list-group-numbered">
+      {% for name, qty in stock_summary %}
+      <li class="list-group-item d-flex justify-content-between align-items-center {% if qty == 0 %}bg-danger text-white{% endif %}">
+        {{ name }}
+        <span class="badge {% if qty == 0 %}bg-light text-dark{% else %}bg-primary{% endif %} rounded-pill">{{ qty }}</span>
       </li>
       {% endfor %}
     </ol>
   </div>
 </div>
+
+<div class="mt-4">
+  <h2>Son İşlemler</h2>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">Tarih</th>
+          <th scope="col">Kullanıcı</th>
+          <th scope="col">İşlem</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for log in actions %}
+        <tr>
+          <td>{{ log.timestamp }}</td>
+          <td>{{ log.username }}</td>
+          <td>{{ log.action }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endblock %}
 
-{% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script>
-const ctx = document.getElementById('hardwareChart');
-new Chart(ctx, {
-  type: 'pie',
-  data: {
-    labels: {{ type_labels | tojson }},
-    datasets: [{
-      data: {{ type_counts | tojson }},
-      backgroundColor: [
-        '#ff6384', '#36a2eb', '#ffce56', '#4bc0c0', '#9966ff', '#ff9f40'
-      ],
-    }]
-  }
-});
-</script>
-{% endblock %}
+{% block scripts %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- Replace factory chart with split layout showing device counts and stock levels; highlight empty stock in red
- Add recent activity table and update greeting text
- Apply white background with blue stroke pattern

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a46c32f400832baa123a2d8f449991