### PR TITLE
Add SVG smoke ribbon animation to page top

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -53,6 +53,7 @@
   </style>
 </head>
 <body>
+  {% include 'partials/smoke_ribbon.html' %}
   <div class="content-wrapper">
   <div class="d-flex" style="height:100vh; width:100%; overflow-y:auto;">
     <nav class="sidebar flex-shrink-0 p-3 text-white bg-dark" style="width:200px; position: sticky; top: 0; height: 100vh;">

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -12,6 +12,8 @@
             align-items: center;
             height: 100vh;
             margin: 0;
+            overflow-x: hidden;
+            position: relative;
         }
         .login-container {
             background: #fff;
@@ -20,6 +22,8 @@
             box-shadow: 0 4px 8px rgba(0,0,0,0.1);
             text-align: center;
             width: 300px;
+            position: relative;
+            z-index: 2;
         }
         .login-container h2 {
             margin-top: 0;
@@ -49,6 +53,7 @@
     </style>
 </head>
 <body>
+    {% include 'partials/smoke_ribbon.html' %}
     <div class="login-container">
         <h2>Şifre Değiştir</h2>
         {% if error %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -53,6 +53,7 @@
     </style>
 </head>
 <body>
+    {% include 'partials/smoke_ribbon.html' %}
     <div class="login-container">
         <img src="/image/onurum.png" alt="Onurum" style="width: 200px; margin-bottom: 1rem;">
         <h2>Hoş geldiniz</h2>

--- a/templates/partials/smoke_ribbon.html
+++ b/templates/partials/smoke_ribbon.html
@@ -1,0 +1,64 @@
+<style>
+  .smoke-ribbon-wrap{
+    position:fixed;
+    top:0;
+    left:0;
+    width:100%;
+    height:60vh;
+    pointer-events:none;
+    z-index:-1;
+  }
+  .smoke-ribbon-title{
+    position:absolute;
+    inset:auto 0 0 0;
+    text-align:center;
+    font:600 18px/1.4 system-ui,Arial;
+    color:#2a2a2a;
+    padding-bottom:8px;
+  }
+  .smoke-flow{animation:smoke-flow 18s linear infinite;}
+  @keyframes smoke-flow{from{transform:translateX(0);}to{transform:translateX(-8%);}}
+</style>
+<div class="smoke-ribbon-wrap" aria-hidden="true">
+  <svg class="smoke-flow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" width="100%" height="100%" preserveAspectRatio="xMidYMid slice">
+    <defs>
+      <linearGradient id="ink" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#1e5fff" stop-opacity="0.85"/>
+        <stop offset="50%" stop-color="#1a66ff" stop-opacity="0.55"/>
+        <stop offset="100%" stop-color="#0f53ff" stop-opacity="0.85"/>
+      </linearGradient>
+      <filter id="smokeFilter" x="-20%" y="-20%" width="140%" height="140%">
+        <feTurbulence id="turb" type="fractalNoise" baseFrequency="0.004 0.008" numOctaves="3" seed="7" stitchTiles="stitch" result="noise"/>
+        <feGaussianBlur in="noise" stdDeviation="1.2" result="softNoise"/>
+        <feDisplacementMap in="SourceGraphic" in2="softNoise" scale="28" xChannelSelector="R" yChannelSelector="G"/>
+        <feGaussianBlur stdDeviation="0.8"/>
+        <animate xlink:href="#turb" attributeName="baseFrequency" values="0.004 0.008; 0.006 0.010; 0.004 0.008" dur="16s" repeatCount="indefinite"/>
+        <animate xlink:href="#turb" attributeName="seed" values="7;8;9;7" dur="24s" repeatCount="indefinite"/>
+      </filter>
+      <mask id="ribbonMask">
+        <rect width="1200" height="600" fill="black"/>
+        <path d="M -50,520
+                 C 150,450  260,420  360,380
+                 C 520,320  640,260  760,220
+                 C 900,175 1030,250 1220,120"
+              fill="none" stroke="white" stroke-width="140" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+          <animate attributeName="stroke-width" values="130;150;130" dur="12s" repeatCount="indefinite"/>
+        </path>
+        <path d="M -50,540
+                 C 160,470  270,440  370,400
+                 C 520,345  640,285  770,245
+                 C 920,205 1040,270 1220,140"
+              fill="none" stroke="white" stroke-width="70" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+      </mask>
+    </defs>
+    <g filter="url(#smokeFilter)" mask="url(#ribbonMask)">
+      <rect x="-100" y="-50" width="1500" height="700" fill="url(#ink)"/>
+    </g>
+    <path d="M -50,520
+             C 150,450 260,420 360,380
+             C 520,320 640,260 760,220
+             C 900,175 1030,250 1220,120"
+          fill="none" stroke="rgba(0,30,120,.25)" stroke-width="3" stroke-linecap="round"/>
+  </svg>
+  <div class="smoke-ribbon-title">Mavi duman şeridi (SVG filtre ile)</div>
+</div>


### PR DESCRIPTION
## Summary
- move smoke ribbon behind all content so it stays in the background
- include smoke ribbon partial on login and change-password pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47e4c9c50832bb278b0343ab6baa5