### PR TITLE
style: add gradient background and restructure login page

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -4,86 +4,104 @@
     <meta charset="UTF-8">
     <title>Giriş</title>
     <style>
-        body {
-            margin: 0;
-            height: 100vh;
-            background: linear-gradient(180deg, #4facfe 0%, #00f2fe 100%);
-            background-attachment: fixed;
-            overflow: hidden;
-            font-family: Arial, sans-serif;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            position: relative;
-        }
-        body::after {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: url("data:image/svg+xml;utf8,
-                <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1440 320'>
-                  <path fill='%23ffffff11' d='M0,64L48,69.3C96,75,192,85,288,101.3C384,117,480,139,576,144C672,149,768,139,864,128C960,117,1056,107,1152,117.3C1248,128,1344,160,1392,176L1440,192L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z'></path>
-                </svg>") no-repeat bottom;
-            background-size: cover;
-            opacity: 0.5;
-        }
-        .login-container {
-            background: #fff;
-            padding: 2rem;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-            text-align: center;
-            width: 300px;
-            position: relative;
-            z-index: 2;
-        }
-        .login-container h2 {
-            margin-top: 0;
-        }
-        .login-container input {
-            width: 100%;
-            padding: 0.5rem;
-            margin: 0.5rem 0;
-            box-sizing: border-box;
-        }
-        .login-container button {
-            width: 100%;
-            padding: 0.5rem;
-            background-color: #007bff;
-            color: #fff;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        .login-container button:hover {
-            background-color: #0056b3;
-        }
-        .error {
-            color: red;
-            margin-bottom: 1rem;
-        }
+html,body{
+  height:100%;
+  margin:0;
+  font-family: Arial, sans-serif;
+}
+
+/* Arka plan katmanı */
+#bg{
+  position:fixed; inset:0;
+  z-index:0; pointer-events:none;
+  background: linear-gradient(180deg, #6ec9ff 0%, #00d4ff 100%);
+}
+
+/* Dalga katmanı (SVG) */
+#bg::after{
+  content:"";
+  position:absolute; left:0; right:0; bottom:0;
+  height:55vh;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1440 320' preserveAspectRatio='none'><path fill='%23ffffff22' d='M0,64L48,80C96,96,192,128,288,149.3C384,171,480,181,576,160C672,139,768,85,864,74.7C960,64,1056,96,1152,122.7C1248,149,1344,171,1392,181.3L1440,192L1440,320L0,320Z'></path></svg>") no-repeat bottom;
+  background-size: cover;
+  opacity:.45;
+  animation: waveMove 30s linear infinite;
+}
+
+@keyframes waveMove{
+  from{ background-position-x:0; }
+  to{ background-position-x:1000px; }
+}
+
+/* İçerik katmanı */
+.page{
+  position:relative;
+  z-index:2; /* login kartını üste al */
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+}
+
+.login-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  text-align: center;
+  width: 300px;
+}
+
+.login-card h2 {
+  margin-top: 0;
+}
+
+.login-card input {
+  width: 100%;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  box-sizing: border-box;
+}
+
+.login-card button {
+  width: 100%;
+  padding: 0.5rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.login-card button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: red;
+  margin-bottom: 1rem;
+}
     </style>
 </head>
 <body>
-    <div class="login-container">
-        <img src="/image/onurum.png" alt="Onurum" style="width: 200px; margin-bottom: 1rem;">
-        <h2>Hoş geldiniz</h2>
-        {% if error %}
-        <p class="error">{{ error }}</p>
-        {% endif %}
-        <form action="/login" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-            <input type="text" name="username" placeholder="Kullanıcı Adı" required>
-            <input type="password" name="password" placeholder="Şifre" required>
-            <label style="display:flex;align-items:center;margin:0.5rem 0;">
-                <input type="checkbox" name="remember" style="margin-right:0.5rem;width: 30px;"> Beni Hatırla
-            </label>
-            <button type="submit">Giriş Yap</button>
-        </form>
-    </div>
+    <div id="bg"></div>
+    <main class="page">
+        <div class="login-card">
+            <img src="/image/onurum.png" alt="Onurum" style="width: 200px; margin-bottom: 1rem;">
+            <h2>Hoş geldiniz</h2>
+            {% if error %}
+            <p class="error">{{ error }}</p>
+            {% endif %}
+            <form action="/login" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="text" name="username" placeholder="Kullanıcı Adı" required>
+                <input type="password" name="password" placeholder="Şifre" required>
+                <label style="display:flex;align-items:center;margin:0.5rem 0;">
+                    <input type="checkbox" name="remember" style="margin-right:0.5rem;width: 30px;"> Beni Hatırla
+                </label>
+                <button type="submit">Giriş Yap</button>
+            </form>
+        </div>
+    </main>
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             const getCookie = (name) => {


### PR DESCRIPTION
## Summary
- add fixed gradient and wave background layer on login page
- wrap login form in main.page and login-card containers
- include optional slow wave animation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e4832ec4832bb0dc7792731b0ee4