### PR TITLE
Redirect to change password when required

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -43,7 +43,8 @@ async def login(
         request.session["full_name"] = (
             f"{user.first_name or ''} {user.last_name or ''}".strip()
         )
-        response = RedirectResponse("/", status_code=303)
+        redirect_url = "/change-password" if user.must_change_password else "/"
+        response = RedirectResponse(redirect_url, status_code=303)
         db.query(RememberToken).filter(
             RememberToken.user_id == user.id
         ).delete()


### PR DESCRIPTION
## Summary
- Redirect users to `/change-password` upon login when `must_change_password` is set
- Extend test helpers and add regression test ensuring password change resets the flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9f6e96c832bbd4068815b00fdd4