### PR TITLE
Ensure change password form remains clickable

### DIFF
--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <title>Şifre Değiştir</title>
     <link rel="stylesheet" href="{{ url_for('static', path='css/custom.css') }}">
+    <style>
+        body::after {
+            pointer-events: none;
+            z-index: -1;
+        }
+    </style>
 </head>
 <body>
     <div id="bg"></div>


### PR DESCRIPTION
## Summary
- prevent change-password overlay from intercepting clicks by disabling pointer events and lowering its stacking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed7c46c8832baccecba7d88eb78d