### PR TITLE
Prevent overlay from blocking content

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,8 @@
         </svg>") no-repeat bottom;
       background-size: cover;
       opacity: 0.5;
+      pointer-events: none;
+      z-index: -1;
     }
     .content-wrapper{
       position:relative;


### PR DESCRIPTION
## Summary
- ensure the body::after background overlay doesn't intercept clicks by disabling pointer events and pushing it behind content

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f0437348832b8c6fc95e8aa7f736