### PR TITLE
Fix modal buttons when Bootstrap JS missing

### DIFF
--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -335,8 +335,8 @@ editButton.addEventListener('click', () => {
         const input = form.querySelector(`[name="${cell.dataset.col}"]`);
         if (input) input.value = cell.innerText.trim();
     });
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    const modal = createModal('editModal');
+    if (modal) modal.show();
     loadHistory(tableName, form.accessory_id.value);
 });
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -144,6 +144,42 @@
         }
       });
     });
+
+    function createModal(id){
+      const el = document.getElementById(id);
+      if (!el) return null;
+      if (window.bootstrap && bootstrap.Modal){
+        return new bootstrap.Modal(el);
+      }
+      return {
+        show(){ el.style.display = 'block'; },
+        hide(){ el.style.display = 'none'; }
+      };
+    }
+
+    if (!window.bootstrap){
+      document.addEventListener('click', (e) => {
+        const openTrigger = e.target.closest('[data-bs-toggle="modal"]');
+        if (openTrigger){
+          e.preventDefault();
+          const targetId = openTrigger.getAttribute('data-bs-target');
+          if (targetId){
+            const modal = createModal(targetId.replace('#',''));
+            if (modal) modal.show();
+          }
+          return;
+        }
+        const closeTrigger = e.target.closest('[data-bs-dismiss="modal"]');
+        if (closeTrigger){
+          e.preventDefault();
+          const modalEl = closeTrigger.closest('.modal');
+          if (modalEl){
+            const modal = createModal(modalEl.id);
+            if (modal) modal.hide();
+          }
+        }
+      });
+    }
     function makeTableResizable(table){
       const ths = table.querySelectorAll('th');
       ths.forEach((th, i) => {
@@ -318,8 +354,8 @@
     });
     function showAlert(message){
       document.getElementById('alertModalBody').innerText = message;
-      const alertModal = new bootstrap.Modal(document.getElementById('alertModal'));
-      alertModal.show();
+      const alertModal = createModal('alertModal');
+      if (alertModal) alertModal.show();
     }
   </script>
   {% block scripts %}{% endblock %}

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -329,16 +329,16 @@ editButton.addEventListener('click', () => {
         const input = form.querySelector(`[name="${cell.dataset.col}"]`);
         if (input) input.value = cell.innerText.trim();
     });
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    const modal = createModal('editModal');
+    if (modal) modal.show();
     loadHistory(tableName, form.item_id.value);
 });
 
-const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));
+const deleteModal = createModal('confirmDeleteModal');
 document.getElementById('delete-selected').addEventListener('click', () => {
     const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => cb.value);
     if (!ids.length) return;
-    deleteModal.show();
+    if (deleteModal) deleteModal.show();
 });
 
 document.getElementById('confirm-delete').addEventListener('click', async () => {
@@ -348,7 +348,7 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids })
     });
-    deleteModal.hide();
+    if (deleteModal) deleteModal.hide();
     location.reload();
 });
 const perPageSelect = document.getElementById('per-page');

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -359,16 +359,16 @@ editButton.addEventListener('click', () => {
         const input = form.querySelector(`[name="${cell.dataset.col}"]`);
         if (input) input.value = cell.innerText.trim();
     });
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    const modal = createModal('editModal');
+    if (modal) modal.show();
     loadHistory(tableName, form.license_id.value);
 });
 
-const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));
+const deleteModal = createModal('confirmDeleteModal');
 document.getElementById('delete-selected').addEventListener('click', () => {
     const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => cb.value);
     if (!ids.length) return;
-    deleteModal.show();
+    if (deleteModal) deleteModal.show();
 });
 
 document.getElementById('confirm-delete').addEventListener('click', async () => {
@@ -378,7 +378,7 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids })
     });
-    deleteModal.hide();
+    if (deleteModal) deleteModal.hide();
     location.reload();
 });
 const perPageSelect = document.getElementById('per-page');

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -345,8 +345,8 @@ assignButton.addEventListener('click', () => {
     }
     const form = document.getElementById('assignForm');
     form.stock_id.value = checked[0].value;
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    const modal = createModal('editModal');
+    if (modal) modal.show();
 });
 
 document.getElementById('assignForm').addEventListener('submit', async (e) => {
@@ -358,8 +358,8 @@ document.getElementById('assignForm').addEventListener('submit', async (e) => {
         body: formData
     });
     if (res.ok) {
-        const modal = bootstrap.Modal.getInstance(document.getElementById('editModal'));
-        modal.hide();
+        const modal = createModal('editModal');
+        if (modal) modal.hide();
         location.reload();
     } else {
         const data = await res.json();
@@ -367,11 +367,11 @@ document.getElementById('assignForm').addEventListener('submit', async (e) => {
     }
 });
 
-const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));
+const deleteModal = createModal('confirmDeleteModal');
 document.getElementById('delete-selected').addEventListener('click', () => {
     const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => cb.value);
     if (!ids.length) return;
-    deleteModal.show();
+    if (deleteModal) deleteModal.show();
 });
 
 document.getElementById('confirm-delete').addEventListener('click', async () => {
@@ -381,7 +381,7 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids })
     });
-    deleteModal.hide();
+    if (deleteModal) deleteModal.hide();
     location.reload();
 });
 const perPageSelect = document.getElementById('per-page');

--- a/templates/talep.html
+++ b/templates/talep.html
@@ -247,8 +247,8 @@ document.getElementById('transfer-selected').addEventListener('click', function(
     container.appendChild(div);
     initSearchableSelects(div);
   });
-  const modal = new bootstrap.Modal(document.getElementById('transferModal'));
-  modal.show();
+  const modal = createModal('transferModal');
+  if (modal) modal.show();
 });
 document.getElementById('confirm-transfer').addEventListener('click', function(){
   const rows = document.querySelectorAll('#transfer-rows .transfer-row');
@@ -351,8 +351,8 @@ document.getElementById('stock-transfer-selected').addEventListener('click', fun
     `;
     container.appendChild(div);
   });
-  const modal = new bootstrap.Modal(document.getElementById('stockTransferModal'));
-  modal.show();
+  const modal = createModal('stockTransferModal');
+  if (modal) modal.show();
 });
 document.getElementById('confirm-stock-transfer').addEventListener('click', function(){
   const rows = document.querySelectorAll('#stock-transfer-rows .stock-transfer-row');

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -326,16 +326,16 @@ editButton.addEventListener('click', () => {
         const input = form.querySelector(`[name="${cell.dataset.col}"]`);
         if (input) input.value = cell.innerText.trim();
     });
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    const modal = createModal('editModal');
+    if (modal) modal.show();
     loadHistory(tableName, form.printer_id.value);
 });
 
-const deleteModal = new bootstrap.Modal(document.getElementById('confirmDeleteModal'));
+const deleteModal = createModal('confirmDeleteModal');
 document.getElementById('delete-selected').addEventListener('click', () => {
     const ids = Array.from(document.querySelectorAll('.row-check:checked')).map(cb => cb.value);
     if (!ids.length) return;
-    deleteModal.show();
+    if (deleteModal) deleteModal.show();
 });
 
 document.getElementById('confirm-delete').addEventListener('click', async () => {
@@ -345,7 +345,7 @@ document.getElementById('confirm-delete').addEventListener('click', async () => 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids })
     });
-    deleteModal.hide();
+    if (deleteModal) deleteModal.hide();
     location.reload();
 });
 const perPageSelect = document.getElementById('per-page');


### PR DESCRIPTION
## Summary
- add `createModal` helper with no-Bootstrap fallbacks and universal modal click handlers
- replace direct `bootstrap.Modal` calls in inventory-related templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5672c7718832bbdc33ad5b183c74a