### PR TITLE
Include request in template context

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -29,7 +29,9 @@ def admin_page(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
             )
         )
     users = query.all()
-    return templates.TemplateResponse(request, "admin.html", {"users": users, "q": q})
+    return templates.TemplateResponse(
+        "admin.html", {"request": request, "users": users, "q": q}
+    )
 
 
 @router.post("/admin/create")
@@ -47,9 +49,13 @@ def create_user(
     if db.query(User).filter(User.username == username).first():
         users = db.query(User).all()
         return templates.TemplateResponse(
-            request,
             "admin.html",
-            {"users": users, "error": "Kullanıcı mevcut", "q": ""},
+            {
+                "request": request,
+                "users": users,
+                "error": "Kullanıcı mevcut",
+                "q": "",
+            },
             status_code=400,
         )
     user = User(
@@ -84,7 +90,7 @@ def edit_user_form(
     if not target:
         return RedirectResponse("/admin", status_code=303)
     return templates.TemplateResponse(
-        request, "admin_edit.html", {"target": target}
+        "admin_edit.html", {"request": request, "target": target}
     )
 
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -18,7 +18,7 @@ def login_form(request: Request, csrf_protect: CsrfProtect = Depends()) -> HTMLR
     """Render the login form."""
     token, signed = csrf_protect.generate_csrf_tokens()
     response = templates.TemplateResponse(
-        request, "login.html", {"csrf_token": token}
+        "login.html", {"request": request, "csrf_token": token}
     )
     csrf_protect.set_csrf_cookie(signed, response)
     return response
@@ -71,9 +71,12 @@ async def login(
     # error from missing/invalid CSRF data on the next attempt.
     token, signed = csrf_protect.generate_csrf_tokens()
     response = templates.TemplateResponse(
-        request,
         "login.html",
-        {"error": "Invalid credentials", "csrf_token": token},
+        {
+            "request": request,
+            "error": "Invalid credentials",
+            "csrf_token": token,
+        },
         status_code=401,
     )
     csrf_protect.set_csrf_cookie(signed, response)

--- a/routes/common_list.py
+++ b/routes/common_list.py
@@ -92,6 +92,6 @@ def list_items(
     csrf_protect = CsrfProtect()
     token, signed = csrf_protect.generate_csrf_tokens()
     context["csrf_token"] = token
-    response = templates.TemplateResponse(request, template_name, context)
+    response = templates.TemplateResponse(template_name, context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response

--- a/routes/connections.py
+++ b/routes/connections.py
@@ -13,7 +13,7 @@ router = APIRouter(dependencies=[Depends(require_admin)])
 @router.get("/connections", response_class=HTMLResponse)
 def connections_form(request: Request) -> HTMLResponse:
     """Render the LDAP connection form."""
-    return templates.TemplateResponse(request, "connections.html")
+    return templates.TemplateResponse("connections.html", {"request": request})
 
 
 @router.post("/connections", response_class=HTMLResponse)
@@ -32,15 +32,13 @@ def test_connection(
         conn.search(base_dn, "(objectClass=*)", attributes=["cn"])
         conn.unbind()
         return templates.TemplateResponse(
-            request,
             "connections.html",
-            {"success": "Bağlantı başarılı"},
+            {"request": request, "success": "Bağlantı başarılı"},
         )
     except Exception as exc:  # pragma: no cover - network failures
         return templates.TemplateResponse(
-            request,
             "connections.html",
-            {"error": str(exc)},
+            {"request": request, "error": str(exc)},
             status_code=400,
         )
 

--- a/routes/inventory_pages.py
+++ b/routes/inventory_pages.py
@@ -114,7 +114,7 @@ def inventory_page(
         "current_user_id": request.session.get("user_id"),
         "csrf_token": token,
     }
-    response = templates.TemplateResponse(request, "envanter.html", context)
+    response = templates.TemplateResponse("envanter.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -200,7 +200,7 @@ def printer_page(
         "current_user_id": request.session.get("user_id"),
         "csrf_token": token,
     }
-    response = templates.TemplateResponse(request, "yazici.html", context)
+    response = templates.TemplateResponse("yazici.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -296,7 +296,7 @@ def license_page(
         "csrf_token": token,
         "active_tab": "license",
     }
-    response = templates.TemplateResponse(request, "lisans.html", context)
+    response = templates.TemplateResponse("lisans.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -369,7 +369,7 @@ def accessories_page(
         "current_user_id": request.session.get("user_id"),
         "csrf_token": token,
     }
-    response = templates.TemplateResponse(request, "aksesuar.html", context)
+    response = templates.TemplateResponse("aksesuar.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -395,12 +395,13 @@ def requests_page(
 
     token, signed = csrf_protect.generate_csrf_tokens()
     context = {
+        "request": request,
         "groups": groups,
         "lookups": lookups,
         "today": date.today().isoformat(),
         "csrf_token": token,
     }
-    response = templates.TemplateResponse(request, "talep.html", context)
+    response = templates.TemplateResponse("talep.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -597,6 +598,7 @@ def lists_page(
 ) -> HTMLResponse:
     """Render the lists management page."""
     context = {
+        "request": request,
         "brands": db.query(LookupItem).filter_by(type="marka").all(),
         "locations": db.query(LookupItem).filter_by(type="lokasyon").all(),
         "types": db.query(LookupItem).filter_by(type="donanim_tipi").all(),
@@ -611,7 +613,7 @@ def lists_page(
     }
     token, signed = csrf_protect.generate_csrf_tokens()
     context["csrf_token"] = token
-    response = templates.TemplateResponse(request, "listeler.html", context)
+    response = templates.TemplateResponse("listeler.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 
@@ -683,7 +685,9 @@ def profile_page(
     user_id = request.session.get("user_id")
     if user_id:
         user = db.get(User, user_id)
-    return templates.TemplateResponse(request, "profile.html", {"user": user})
+    return templates.TemplateResponse(
+        "profile.html", {"request": request, "user": user}
+    )
 
 
 @router.get("/change-password", response_class=HTMLResponse)
@@ -693,7 +697,7 @@ def change_password_form(
     """Display the password change form."""
     token, signed = csrf_protect.generate_csrf_tokens()
     response = templates.TemplateResponse(
-        request, "change_password.html", {"csrf_token": token}
+        "change_password.html", {"request": request, "csrf_token": token}
     )
     csrf_protect.set_csrf_cookie(signed, response)
     return response
@@ -712,9 +716,11 @@ async def change_password(
     await csrf_protect.validate_csrf(request)
     if new_password != confirm_password:
         return templates.TemplateResponse(
-            request,
             "change_password.html",
-            {"error": "Yeni şifreler uyuşmuyor"},
+            {
+                "request": request,
+                "error": "Yeni şifreler uyuşmuyor",
+            },
             status_code=400,
         )
 
@@ -722,9 +728,11 @@ async def change_password(
     user = db.get(User, user_id) if user_id else None
     if not user or not pwd_context.verify(old_password, user.password):
         return templates.TemplateResponse(
-            request,
             "change_password.html",
-            {"error": "Mevcut şifre yanlış"},
+            {
+                "request": request,
+                "error": "Mevcut şifre yanlış",
+            },
             status_code=400,
         )
 

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -52,13 +52,17 @@ def _main_context(db: Session) -> dict:
 @router.get("/", response_class=HTMLResponse)
 def root(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
     """Render the main dashboard page."""
-    return templates.TemplateResponse(request, "main.html", _main_context(db))
+    context = _main_context(db)
+    context["request"] = request
+    return templates.TemplateResponse("main.html", context)
 
 
 @router.get("/home", response_class=HTMLResponse)
 def home_page(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
     """Render the dashboard from the /home path."""
-    return templates.TemplateResponse(request, "main.html", _main_context(db))
+    context = _main_context(db)
+    context["request"] = request
+    return templates.TemplateResponse("main.html", context)
 
 
 @router.get("/stock/status", response_class=HTMLResponse)
@@ -86,8 +90,13 @@ def stock_status_page(
     summary = [(name, qty or 0) for name, qty in totals]
     selected = load_home_stock()
     token, signed = csrf_protect.generate_csrf_tokens()
-    context = {"summary": summary, "selected": selected, "csrf_token": token}
-    response = templates.TemplateResponse(request, "stok_durumu.html", context)
+    context = {
+        "request": request,
+        "summary": summary,
+        "selected": selected,
+        "csrf_token": token,
+    }
+    response = templates.TemplateResponse("stok_durumu.html", context)
     csrf_protect.set_csrf_cookie(signed, response)
     return response
 


### PR DESCRIPTION
## Summary
- render templates with `request` included in context
- use `templates.TemplateResponse` with template name first across routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a56debba20832bb1cf9e5c4a556e50