### PR TITLE
Fix inventory action buttons by safely rendering user id

### DIFF
--- a/templates/aksesuar.html
+++ b/templates/aksesuar.html
@@ -217,7 +217,7 @@
 {% block scripts %}
 <script>
 const tableName = "{{ table_name }}";
-const currentUserId = {{ current_user_id }};
+const currentUserId = {{ current_user_id | tojson }};
 const columnLabels = {{ column_labels | tojson }};
 window.tableName = tableName;
 window.filterEndpoint = "/column-values";

--- a/templates/envanter.html
+++ b/templates/envanter.html
@@ -227,7 +227,7 @@
 {% block scripts %}
 <script>
 const tableName = "{{ table_name }}";
-const currentUserId = {{ current_user_id }};
+const currentUserId = {{ current_user_id | tojson }};
 const columnLabels = {{ column_labels | tojson }};
 window.tableName = tableName;
 window.filterEndpoint = "/column-values";

--- a/templates/lisans.html
+++ b/templates/lisans.html
@@ -241,7 +241,7 @@
 {% block scripts %}
 <script>
 const tableName = "{{ table_name }}";
-const currentUserId = {{ current_user_id }};
+const currentUserId = {{ current_user_id | tojson }};
 const columnLabels = {{ column_labels | tojson }};
 window.tableName = tableName;
 window.filterEndpoint = "/column-values";

--- a/templates/stok.html
+++ b/templates/stok.html
@@ -232,7 +232,7 @@
 {% block scripts %}
 <script>
 const tableName = "{{ table_name }}";
-const currentUserId = {{ current_user_id }};
+const currentUserId = {{ current_user_id | tojson }};
 const columnLabels = {{ column_labels | tojson }};
 window.tableName = tableName;
 window.filterEndpoint = "/column-values";

--- a/templates/yazici.html
+++ b/templates/yazici.html
@@ -224,7 +224,7 @@
 {% block scripts %}
 <script>
 const tableName = "{{ table_name }}";
-const currentUserId = {{ current_user_id }};
+const currentUserId = {{ current_user_id | tojson }};
 const columnLabels = {{ column_labels | tojson }};
 window.tableName = tableName;
 window.filterEndpoint = "/column-values";


### PR DESCRIPTION
## Summary
- Safely embed `current_user_id` with `tojson` in inventory and related templates so JavaScript can run even when the user id is missing
- Ensures New Record, Edit, and Delete buttons remain clickable across inventory pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a57425e710832bb094662578d0f8d1