### PR TITLE
Remove blocking background overlay to re-enable button clicks

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -7,6 +7,10 @@ html, body {
   font-family: Arial, sans-serif;
 }
 
+body {
+  background: linear-gradient(180deg, #6ec9ff 0%, #00d4ff 100%);
+}
+
 /* Sol menü yine kendi içinde dikey scroll alsın (varsa) */
 .sidebar { height: 100vh; overflow-y: auto; }
 
@@ -85,37 +89,6 @@ html, body {
 /* ------------------------ */
 /*  Giriş / Şifre Sayfaları */
 /* ------------------------ */
-
-/* Arka plan katmanı */
-
-#bg {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background: linear-gradient(180deg, #6ec9ff 0%, #00d4ff 100%);
-}
-
-/* Dalga katmanı (SVG) */
-#bg::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 55vh;
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1440 320' preserveAspectRatio='none'><path fill='%23ffffff22' d='M0,64L48,80C96,96,192,128,288,149.3C384,171,480,181,576,160C672,139,768,85,864,74.7C960,64,1056,96,1152,122.7C1248,149,1344,171,1392,181.3L1440,192L1440,320L0,320Z'></path></svg>") no-repeat bottom;
-  background-size: cover;
-  opacity: .45;
-  animation: waveMove 30s linear infinite;
-  pointer-events: none;
-  z-index: -1;
-}
-
-@keyframes waveMove {
-  from { background-position-x: 0; }
-  to { background-position-x: 1000px; }
-}
 
 /* İçerik katmanı */
 .page {

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,22 +22,6 @@
       color:#111;
       position:relative;
     }
-    body::after{
-      content:"";
-      position:fixed;
-      top:0;
-      left:0;
-      right:0;
-      bottom:0;
-      background: url("data:image/svg+xml;utf8,
-        <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1440 320'>
-          <path fill='%23ffffff11' d='M0,64L48,69.3C96,75,192,85,288,101.3C384,117,480,139,576,144C672,149,768,139,864,128C960,117,1056,107,1152,117.3C1248,128,1344,160,1392,176L1440,192L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z'></path>
-        </svg>") no-repeat bottom;
-      background-size: cover;
-      opacity: 0.5;
-      pointer-events: none;
-      z-index: -1;
-    }
     .content-wrapper{
       position:relative;
       z-index:1;

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -4,15 +4,8 @@
     <meta charset="UTF-8">
     <title>Şifre Değiştir</title>
     <link rel="stylesheet" href="{{ url_for('static', path='css/custom.css') }}">
-    <style>
-        body::after {
-            pointer-events: none;
-            z-index: -1;
-        }
-    </style>
 </head>
 <body>
-    <div id="bg"></div>
     <main class="page">
         <div class="login-card">
             <img src="/image/onurum.png" alt="Onurum" class="login-logo">

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/custom.css') }}">
 </head>
 <body>
-    <div id="bg"></div>
     <main class="page">
         <div class="login-card">
             <img src="/image/onurum.png" alt="Onurum" class="login-logo">


### PR DESCRIPTION
## Summary
- Remove background pseudo-element from base layout to prevent click interception
- Drop unused login background layer and apply gradient directly on body

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a579dd61a0832b97d3b05c10132870