### PR TITLE
Add license management and logging

### DIFF
--- a/db/migrations/004_license_tables.sql
+++ b/db/migrations/004_license_tables.sql
@@ -1,0 +1,26 @@
+-- Create license table and log table
+CREATE TABLE IF NOT EXISTS license (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  adi TEXT NOT NULL,
+  anahtar TEXT,
+  sorumlu_personel TEXT,
+  ifs_no TEXT,
+  tarih DATE,
+  islem_yapan TEXT,
+  mail_adresi TEXT,
+  inventory_id INTEGER REFERENCES hardware_inventory(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_license_inventory_id ON license(inventory_id);
+
+CREATE TABLE IF NOT EXISTS license_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  license_id INTEGER NOT NULL REFERENCES license(id) ON DELETE CASCADE,
+  field TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT,
+  changed_by TEXT,
+  changed_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_license_log_license_id ON license_log(license_id);

--- a/models.py
+++ b/models.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import (
@@ -13,7 +14,7 @@ from sqlalchemy import (
     func,
     ForeignKey,
 )
-from sqlalchemy.orm import declarative_base, sessionmaker, Session
+from sqlalchemy.orm import declarative_base, sessionmaker, Session, relationship
 from passlib.context import CryptContext
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -45,6 +46,9 @@ class HardwareInventory(Base):
     ifs_no = Column(String)
     tarih = Column(Date)
     islem_yapan = Column(String)
+    licenses = relationship(
+        "License", back_populates="inventory", passive_deletes=True
+    )
 
 
 class DeletedHardwareInventory(Base):
@@ -142,6 +146,38 @@ class LicenseInventory(Base):
     tarih = Column(Date)
     islem_yapan = Column(String)
     notlar = Column(Text)
+
+
+class License(Base):
+    __tablename__ = "license"
+    id = Column(Integer, primary_key=True, index=True)
+    adi = Column(String, nullable=False)
+    anahtar = Column(String, nullable=True)
+    sorumlu_personel = Column(String, nullable=True)
+    ifs_no = Column(String, nullable=True)
+    tarih = Column(Date, nullable=True)
+    islem_yapan = Column(String, nullable=True)
+    mail_adresi = Column(String, nullable=True)
+    inventory_id = Column(
+        Integer, ForeignKey("hardware_inventory.id", ondelete="SET NULL")
+    )
+    inventory = relationship(
+        "HardwareInventory", back_populates="licenses"
+    )
+
+
+class LicenseLog(Base):
+    __tablename__ = "license_log"
+    id = Column(Integer, primary_key=True, index=True)
+    license_id = Column(
+        Integer, ForeignKey("license.id", ondelete="CASCADE")
+    )
+    field = Column(String, nullable=False)
+    old_value = Column(Text)
+    new_value = Column(Text)
+    changed_by = Column(String)
+    changed_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    license = relationship("License")
 
 
 class StockItem(Base):

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -13,6 +13,7 @@ from .inventory_pages import router as inventory_pages_router
 from .inventory import router as inventory_router
 from .connections import router as connections_router
 from .trash import router as trash_router
+from .license import router as license_router
 
 router = APIRouter()
 router.include_router(auth_router)
@@ -26,5 +27,6 @@ router.include_router(connections_router)
 router.include_router(inventory_logs_router)
 router.include_router(reports_router)
 router.include_router(trash_router)
+router.include_router(license_router)
 
 __all__ = ["router"]

--- a/routes/license.py
+++ b/routes/license.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+from datetime import date, datetime
+from typing import Optional
+
+from fastapi import APIRouter, Request, Depends, Form
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session, joinedload
+
+from models import License, HardwareInventory, LicenseLog, get_db
+from fastapi.templating import Jinja2Templates
+
+router = APIRouter()
+templates = Jinja2Templates(directory="templates")
+
+# Alias for readability
+Inventory = HardwareInventory
+
+
+@router.get("/licenses", name="license_list")
+def license_list(request: Request, db: Session = Depends(get_db)):
+    lisanslar = (
+        db.query(License)
+        .options(joinedload(License.inventory))
+        .order_by(License.id.desc())
+        .all()
+    )
+    return templates.TemplateResponse(
+        "license_list.html", {"request": request, "lisanslar": lisanslar}
+    )
+
+
+@router.get("/licenses/new", name="license_new")
+def license_new(request: Request, db: Session = Depends(get_db)):
+    envanterler = db.query(Inventory).order_by(Inventory.no.asc()).all()
+    return templates.TemplateResponse(
+        "license_form.html",
+        {
+            "request": request,
+            "form_action": request.url_for("license_create"),
+            "license": None,
+            "envanterler": envanterler,
+        },
+    )
+
+
+@router.post("/licenses", name="license_create")
+def license_create(
+    request: Request,
+    db: Session = Depends(get_db),
+    adi: str = Form(...),
+    anahtar: Optional[str] = Form(None),
+    sorumlu_personel: Optional[str] = Form(None),
+    inventory_id: Optional[int] = Form(None),
+    ifs_no: Optional[str] = Form(None),
+    tarih: Optional[str] = Form(None),
+    islem_yapan: Optional[str] = Form(None),
+    mail_adresi: Optional[str] = Form(None),
+):
+    lic = License(
+        adi=adi,
+        anahtar=anahtar,
+        sorumlu_personel=sorumlu_personel,
+        inventory_id=inventory_id or None,
+        ifs_no=ifs_no,
+        tarih=date.fromisoformat(tarih) if tarih else None,
+        islem_yapan=islem_yapan,
+        mail_adresi=mail_adresi,
+    )
+    db.add(lic)
+    db.commit()
+    return RedirectResponse(request.url_for("license_list"), status_code=303)
+
+
+@router.get("/licenses/{id}/edit", name="license_edit")
+def license_edit(id: int, request: Request, db: Session = Depends(get_db)):
+    lic = db.get(License, id)
+    envanterler = db.query(Inventory).order_by(Inventory.no.asc()).all()
+    return templates.TemplateResponse(
+        "license_form.html",
+        {
+            "request": request,
+            "form_action": request.url_for("license_update", id=id),
+            "license": lic,
+            "envanterler": envanterler,
+        },
+    )
+
+
+@router.post("/licenses/{id}", name="license_update")
+def license_update(
+    id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    adi: str = Form(...),
+    anahtar: Optional[str] = Form(None),
+    sorumlu_personel: Optional[str] = Form(None),
+    inventory_id: Optional[int] = Form(None),
+    ifs_no: Optional[str] = Form(None),
+    tarih: Optional[str] = Form(None),
+    islem_yapan: Optional[str] = Form(None),
+    mail_adresi: Optional[str] = Form(None),
+):
+    lic = db.get(License, id)
+    logs: list[LicenseLog] = []
+
+    def add_log(field: str, old, new):
+        logs.append(
+            LicenseLog(
+                license_id=lic.id,
+                field=field,
+                old_value=str(old) if old is not None else None,
+                new_value=str(new) if new is not None else None,
+                changed_by=islem_yapan or "Sistem",
+                changed_at=datetime.utcnow(),
+            )
+        )
+
+    if lic.sorumlu_personel != sorumlu_personel:
+        add_log("sorumlu_personel", lic.sorumlu_personel, sorumlu_personel)
+
+    if (lic.inventory_id or None) != (inventory_id or None):
+        old_no = None
+        new_no = None
+        if lic.inventory_id:
+            inv_old = db.get(Inventory, lic.inventory_id)
+            old_no = inv_old.no if inv_old else None
+        if inventory_id:
+            inv_new = db.get(Inventory, inventory_id)
+            new_no = inv_new.no if inv_new else None
+        add_log("bagli_envanter_no", old_no, new_no)
+
+    lic.adi = adi
+    lic.anahtar = anahtar
+    lic.sorumlu_personel = sorumlu_personel
+    lic.inventory_id = inventory_id or None
+    lic.ifs_no = ifs_no
+    lic.tarih = date.fromisoformat(tarih) if tarih else None
+    lic.islem_yapan = islem_yapan
+    lic.mail_adresi = mail_adresi
+
+    for lg in logs:
+        db.add(lg)
+
+    db.commit()
+    return RedirectResponse(request.url_for("license_list"), status_code=303)
+
+
+@router.get("/licenses/{id}", name="license_detail")
+def license_detail(id: int, request: Request, db: Session = Depends(get_db)):
+    lic = (
+        db.query(License)
+        .options(joinedload(License.inventory))
+        .filter(License.id == id)
+        .first()
+    )
+    logs = (
+        db.query(LicenseLog)
+        .filter(LicenseLog.license_id == id)
+        .order_by(LicenseLog.changed_at.desc())
+        .all()
+    )
+    return templates.TemplateResponse(
+        "license_detail.html",
+        {"request": request, "license": lic, "logs": logs},
+    )

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+{% block title %}Lisans Detayı{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-3 content">
+
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisans: {{ license.adi }}</h4>
+    <div class="d-flex gap-2">
+      <a class="btn btn-outline-primary btn-sm" href="{{ url_for('license_edit', id=license.id) }}">Düzenle</a>
+      <a class="btn btn-light btn-sm" href="{{ url_for('license_list') }}">← Listeye Dön</a>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted mb-3">Bilgiler</h6>
+          <div class="table-responsive">
+            <table class="table table-sm">
+              <tbody>
+                <tr><th style="width:220px">ID</th><td>{{ license.id }}</td></tr>
+                <tr><th>Lisans Adı</th><td>{{ license.adi }}</td></tr>
+                <tr><th>Lisans Anahtarı</th><td class="text-monospace">{{ license.anahtar or '-' }}</td></tr>
+                <tr><th>Sorumlu Personel</th><td>{{ license.sorumlu_personel or '-' }}</td></tr>
+                <tr>
+                  <th>Bağlı Envanter No</th>
+                  <td>
+                    {% if license.inventory %}
+                      <a href="{{ url_for('inventory_detail', id=license.inventory.id) }}">
+                        {{ license.inventory.no }}
+                      </a>
+                    {% else %}-{% endif %}
+                  </td>
+                </tr>
+                <tr><th>IFS No</th><td>{{ license.ifs_no or '-' }}</td></tr>
+                <tr><th>Tarih</th><td>{{ license.tarih.strftime('%Y-%m-%d') if license.tarih else '-' }}</td></tr>
+                <tr><th>İşlem Yapan</th><td>{{ license.islem_yapan or '-' }}</td></tr>
+                <tr><th>Mail Adresi</th><td>{{ license.mail_adresi or '-' }}</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted mb-3">Değişiklik Logları</h6>
+          {% if logs|length == 0 %}
+            <div class="text-muted">Log kaydı yok.</div>
+          {% else %}
+            <div class="table-responsive">
+              <table class="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th style="width:160px">Tarih</th>
+                    <th>Alan</th>
+                    <th>Eski</th>
+                    <th>Yeni</th>
+                    <th>İşlem Yapan</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for lg in logs %}
+                  <tr>
+                    <td>{{ lg.changed_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                    <td>{{ lg.field }}</td>
+                    <td>{{ lg.old_value or '-' }}</td>
+                    <td>{{ lg.new_value or '-' }}</td>
+                    <td>{{ lg.changed_by or '-' }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<style>
+  .text-monospace { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace; }
+</style>
+{% endblock %}

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}Lisans {{ 'Düzenle' if license else 'Ekle' }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-3 content">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisans {{ 'Düzenle' if license else 'Ekle' }}</h4>
+    <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <form method="post" action="{{ form_action }}">
+        <div class="row g-3">
+          <div class="col-md-6">
+            <label class="form-label">Lisans Adı</label>
+            <input name="adi" class="form-control" value="{{ license.adi if license else '' }}" required>
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Lisans Anahtarı</label>
+            <input name="anahtar" class="form-control" value="{{ license.anahtar if license else '' }}">
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Sorumlu Personel</label>
+            <input name="sorumlu_personel" class="form-control" value="{{ license.sorumlu_personel if license else '' }}">
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Bağlı Olduğu Envanter No</label>
+            <select id="selBagliEnvanter" name="inventory_id" class="form-select">
+              <option value="">(Seçimsiz)</option>
+              {% for inv in envanterler %}
+                <option value="{{ inv.id }}"
+                        {% if license and license.inventory_id == inv.id %}selected{% endif %}>
+                  {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="col-md-4">
+            <label class="form-label">IFS No</label>
+            <input name="ifs_no" class="form-control" value="{{ license.ifs_no if license else '' }}">
+          </div>
+
+          <div class="col-md-4">
+            <label class="form-label">Tarih</label>
+            <input type="date" name="tarih" class="form-control"
+                   value="{{ license.tarih.isoformat() if license and license.tarih }}">
+          </div>
+
+          <div class="col-md-4">
+            <label class="form-label">İşlem Yapan</label>
+            <input name="islem_yapan" class="form-control" value="{{ license.islem_yapan if license else '' }}">
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Mail Adresi</label>
+            <input type="email" name="mail_adresi" class="form-control" value="{{ license.mail_adresi if license else '' }}">
+          </div>
+        </div>
+
+        <div class="d-flex gap-2 mt-4">
+          <button class="btn btn-primary" type="submit">Kaydet</button>
+          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.Choices) {
+      new Choices("#selBagliEnvanter", { searchEnabled: true, itemSelectText: '' });
+    }
+  });
+</script>
+{% endblock %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}Lisanslar{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-3 content">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisanslar</h4>
+    <a class="btn btn-success btn-sm" href="{{ url_for('license_new') }}">Ekle</a>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="table-responsive">
+      <table class="table table-hover mb-0 align-middle">
+        <thead>
+          <tr>
+            <th style="width:80px">ID</th>
+            <th>Bağlı Envanter No</th>
+            <th>Lisans Adı</th>
+            <th>Lisans Anahtarı</th>
+            <th>Sorumlu Personel</th>
+            <th class="text-end" style="width:140px">İşlemler</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if lisanslar|length == 0 %}
+          <tr><td colspan="6" class="text-muted">Kayıt yok</td></tr>
+          {% else %}
+          {% for lic in lisanslar %}
+          <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
+            <td>{{ lic.id }}</td>
+            <td>
+              {% if lic.inventory %}
+                <a href="{{ url_for('inventory_detail', id=lic.inventory.id) }}" onclick="event.stopPropagation()">
+                  {{ lic.inventory.no }}
+                </a>
+              {% else %}-{% endif %}
+            </td>
+            <td>
+              <a href="{{ url_for('license_detail', id=lic.id) }}" onclick="event.stopPropagation()">
+                {{ lic.adi }}
+              </a>
+            </td>
+            <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
+            <td>{{ lic.sorumlu_personel or '-' }}</td>
+            <td class="text-end text-nowrap">
+              <a class="btn btn-sm btn-outline-primary"
+                 href="{{ url_for('license_edit', id=lic.id) }}"
+                 onclick="event.stopPropagation()">Düzenle</a>
+            </td>
+          </tr>
+          {% endfor %}
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `License` and `LicenseLog` models linked to hardware inventory
- implement `/licenses` CRUD routes with change logging
- create corresponding templates and database migration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac04418494832b9028f5141666ed00